### PR TITLE
Soft Delete (task #1396)

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ Load plugin
 bin/cake plugin load Search
 ```
 
+Load required plugin(s)
+```
+bin/cake plugin load Muffin/Trash
+```
+
 Load Component
 
 In your AppController add the following:

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "license": "GPL-2.0",
     "require": {
         "php": ">=5.4.16",
-        "cakephp/cakephp": "~3.0"
+        "cakephp/cakephp": "~3.0",
+        "muffin/trash": "^1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "*",

--- a/config/Migrations/20160916092426_AddTrashedToDashboards.php
+++ b/config/Migrations/20160916092426_AddTrashedToDashboards.php
@@ -1,0 +1,22 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddTrashedToDashboards extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('dashboards');
+        $table->addColumn('trashed', 'datetime', [
+            'default' => null,
+            'null' => false,
+        ]);
+        $table->update();
+    }
+}

--- a/config/Migrations/20160916092634_AddTrashedToSavedSearches.php
+++ b/config/Migrations/20160916092634_AddTrashedToSavedSearches.php
@@ -1,0 +1,22 @@
+<?php
+use Migrations\AbstractMigration;
+
+class AddTrashedToSavedSearches extends AbstractMigration
+{
+    /**
+     * Change Method.
+     *
+     * More information on this method is available here:
+     * http://docs.phinx.org/en/latest/migrations.html#the-change-method
+     * @return void
+     */
+    public function change()
+    {
+        $table = $this->table('saved_searches');
+        $table->addColumn('trashed', 'datetime', [
+            'default' => null,
+            'null' => false,
+        ]);
+        $table->update();
+    }
+}

--- a/src/Model/Table/DashboardsTable.php
+++ b/src/Model/Table/DashboardsTable.php
@@ -32,6 +32,7 @@ class DashboardsTable extends Table
         $this->primaryKey('id');
 
         $this->addBehavior('Timestamp');
+        $this->addBehavior('Muffin/Trash.Trash');
 
         $this->belongsTo('Roles', [
             'foreignKey' => 'role_id',

--- a/src/Model/Table/SavedSearchesTable.php
+++ b/src/Model/Table/SavedSearchesTable.php
@@ -155,6 +155,7 @@ class SavedSearchesTable extends Table
         $this->displayField('name');
         $this->primaryKey('id');
         $this->addBehavior('Timestamp');
+        $this->addBehavior('Muffin/Trash.Trash');
 
         $this->belongsTo('Users', [
             'foreignKey' => 'user_id',


### PR DESCRIPTION
**Introducing soft delete functionality**
This means that no records will actually be dropped from the database. Instead, they will be flagged as `trashed` and will be skipped in `find()` queries.