### PR TITLE
Remove saved search results action (task #2771)

### DIFF
--- a/src/Controller/SearchTrait.php
+++ b/src/Controller/SearchTrait.php
@@ -2,6 +2,7 @@
 namespace Search\Controller;
 
 use Cake\Network\Exception\BadRequestException;
+use Cake\ORM\Query;
 use Cake\ORM\TableRegistry;
 use Search\Controller\Traits\SearchableTrait;
 

--- a/src/Controller/SearchTrait.php
+++ b/src/Controller/SearchTrait.php
@@ -51,37 +51,7 @@ trait SearchTrait
             $this->Flash->error(__('The search could not be saved. Please, try again.'));
         }
 
-        return $this->redirect(['action' => 'search']);
-    }
-
-    /**
-     * Saved result action
-     *
-     * @param  string $id    record id
-     * @return void
-     */
-    public function saveSearchResult($id)
-    {
-        $model = $this->modelClass;
-        $table = TableRegistry::get($this->_tableSearch);
-
-        $search = $table->get($id);
-
-        $this->set('searchName', $search->name);
-
-        $content = json_decode($search->content, true);
-        $this->set('entities', $content['result']);
-
-        // get listing fields
-        if (isset($content['display_columns'])) {
-            $listingFields = $content['display_columns'];
-        } else {
-            $listingFields = $this->SavedSearches->getListingFields($model);
-        }
-
-        $this->set('listingFields', $listingFields);
-
-        $this->render($this->_elementSavedResult);
+        return $this->redirect(['action' => 'search', $id]);
     }
 
     /**

--- a/src/Controller/SearchTrait.php
+++ b/src/Controller/SearchTrait.php
@@ -100,7 +100,6 @@ trait SearchTrait
             } else {
                 // as taken from a saved search result
                 $entities = $search['entities']['result'];
-
             }
             $this->set('entities', $entities);
 

--- a/src/Model/Table/SavedSearchesTable.php
+++ b/src/Model/Table/SavedSearchesTable.php
@@ -328,27 +328,28 @@ class SavedSearchesTable extends Table
         // use query defaults if not set
         $query = array_merge($this->_queryDefaults, $query);
 
-        $query['result'] = $table
-            ->find('all')
-            ->where($where)
-            ->order([$query['sort_by_field'] => $query['sort_by_order']]);
+        if (empty($query['result'])) {
+            $query['result'] = $table
+                ->find('all')
+                ->where($where)
+                ->order([$query['sort_by_field'] => $query['sort_by_order']]);
 
-        // set limit if not 0
-        if (0 < (int)$query['limit']) {
-            $query['result']->limit($query['limit']);
+            // set limit if not 0
+            if (0 < (int)$query['limit']) {
+                $query['result']->limit($query['limit']);
+            }
         }
 
         // if in advanced mode, pre-save search criteria and results
-        if (!isset($criteria['query']) && !empty($criteria)) {
-            $preSaveIds = $this->preSaveSearchCriteriaAndResults(
-                $model,
-                $query,
-                $data,
-                $user['id']
-            );
-            $result['saveSearchCriteriaId'] = $preSaveIds['saveSearchCriteriaId'];
-            $result['saveSearchResultsId'] = $preSaveIds['saveSearchResultsId'];
-        }
+        $preSaveIds = $this->preSaveSearchCriteriaAndResults(
+            $model,
+            $query,
+            $data,
+            $user['id']
+        );
+        $result['saveSearchCriteriaId'] = $preSaveIds['saveSearchCriteriaId'];
+        $result['saveSearchResultsId'] = $preSaveIds['saveSearchResultsId'];
+
         $result['entities'] = $query;
 
         return $result;
@@ -692,9 +693,8 @@ class SavedSearchesTable extends Table
         $search->model = $model;
         $search->shared = $this->getPrivateSharedStatus();
         $search->content = json_encode($data);
-        /*
-        save search criteria
-         */
+
+        // save search criteria
         $this->save($search);
 
         return $search->id;
@@ -716,9 +716,8 @@ class SavedSearchesTable extends Table
         $search->model = $model;
         $search->shared = $this->getPrivateSharedStatus();
         $search->content = json_encode($query);
-        /*
-        save search results
-         */
+
+        // save search results
         $this->save($search);
 
         return $search->id;

--- a/src/Template/Element/saved_searches.ctp
+++ b/src/Template/Element/saved_searches.ctp
@@ -27,13 +27,6 @@
                         switch ($type) {
                             case 'result':
                                 $results[$search->id] = $search->name;
-                                echo $this->Html->link($search->name, [
-                                    'action' => 'save-search-result',
-                                    $search->id
-                                ], [
-                                    'id' => 'view_' . $search->id,
-                                    'class' => 'hidden'
-                                ]);
                                 break;
 
                             case 'criteria':
@@ -100,6 +93,15 @@
                                 echo $this->Form->end();
                                 break;
                         }
+
+                        echo $this->Html->link($search->name, [
+                            'action' => 'search',
+                            $search->id
+                        ], [
+                            'id' => 'view_' . $search->id,
+                            'class' => 'hidden'
+                        ]);
+
                         echo $this->Form->postLink(
                             '<span class="glyphicon glyphicon-minus"></span>',
                             [

--- a/src/Template/Element/search_results.ctp
+++ b/src/Template/Element/search_results.ctp
@@ -1,6 +1,15 @@
 <?php
 use Cake\Event\Event;
 use Cake\Utility\Inflector;
+
+$title = [
+    'main' => $this->name,
+    'sub' => __('search results')
+];
+if (!empty($searchName) && !empty($searchType)) {
+    $title['main'] = $searchName;
+    $title['sub'] = '(' . __('from saved search') . ' ' . $searchType . ')';
+}
 ?>
 
 <?php if (!empty($entities)) : ?>
@@ -9,7 +18,7 @@ use Cake\Utility\Inflector;
         <div class="panel panel-default">
             <div class="panel-heading">
                 <h3 class="panel-title">
-                    <strong><?= isset($searchName) ? $searchName : $this->name; ?></strong> <?= __('search results'); ?>:
+                    <strong><?= $title['main']; ?></strong> <?= $title['sub'] ?>:
                 </h3>
             </div>
             <div class="panel-body">


### PR DESCRIPTION
- Remove saved search results action.
- Added support for GET requests on search action. If id is provided the search criteria, results etc are used from the saved search content.