### PR TITLE
Sort display columns based on listing fields order (task #2813)

### DIFF
--- a/src/Template/Element/search_options.ctp
+++ b/src/Template/Element/search_options.ctp
@@ -11,6 +11,8 @@ foreach ($searchFields as $k => $v) {
         $availableColumns[$k] = $v;
     }
 }
+// sort display columns based on listing fields order
+$displayColumns = array_merge(array_flip($listingFields), $displayColumns);
 ?>
     <div class="row">
         <div class="col-md-4">


### PR DESCRIPTION
Fixes bug when search form gets submitted and the order of display fields is set back to default, instead of what the user has set it to.