### PR TITLE
Fixed a bug with only one report being visible (task #2686)

### DIFF
--- a/src/Model/Table/WidgetsTable.php
+++ b/src/Model/Table/WidgetsTable.php
@@ -137,10 +137,15 @@ class WidgetsTable extends Table
         $this->eventManager()->dispatch($event);
 
         if (!empty($event->result)) {
-            $widgets[] = [
-                'type' => 'report',
-                'data' => array_shift($event->result)
-            ];
+            $data = [];
+            foreach ($event->result as $model => $reports) {
+                foreach ($reports as $reportSlug => $reportInfo) {
+                    $data[$reportInfo['id']] = $reportInfo;
+                }
+            }
+            if (!empty($data)) {
+                $widgets[] = [ 'type' => 'report', 'data' => $data ];
+            }
         }
 
         //assembling all widgets in one


### PR DESCRIPTION
Due to the incorrect shifting of the report data array, only the
first report was visible in the Dashboards editor.