### PR TITLE
using moduleAlias for saved_searches (task #2926)

### DIFF
--- a/src/Model/Table/WidgetsTable.php
+++ b/src/Model/Table/WidgetsTable.php
@@ -122,17 +122,22 @@ class WidgetsTable extends Table
             ->where(['SavedSearches.name IS NOT' => null])
             ->order(['SavedSearches.model', 'SavedSearches.name']);
 
-        $widgets[] = [
-            'type' => 'saved_search',
-            'data' => $savedSearchesTable
+        $savedSearches = $savedSearchesTable
                         ->find()
                         ->select()
                         ->where(['SavedSearches.name IS NOT' => null])
                         ->hydrate(false)
                         ->indexBy('id')
-                        ->toArray()
-        ];
+                        ->toArray();
 
+        foreach ($savedSearches as $id => $savedSearch) {
+            $table = TableRegistry::get($savedSearch['model']);
+            if (method_exists($table, 'moduleAlias')) {
+                $savedSearches[$id]['model'] = $table->moduleAlias();
+            }
+        }
+
+        $widgets[] = ['type' => 'saved_search', 'data' => $savedSearches];
         $event = new Event('Search.Report.getReports', $this);
         $this->eventManager()->dispatch($event);
 


### PR DESCRIPTION
As the users implement moduleAlias to mimic initial model logic, we need to use aliases for the saved searches as well.