### PR TITLE
fixing y axis scaling

### DIFF
--- a/src/Template/Cell/Widget/display_report.ctp
+++ b/src/Template/Cell/Widget/display_report.ctp
@@ -44,6 +44,8 @@ $listingFields = explode(',',$widgetData['info']['columns']);
                                 echo $this->Html->script('https://d3js.org/d3.v4.min.js');
                                 echo $this->Html->script('https://d3js.org/d3-axis.v1.min.js');
                                 echo $this->Html->script('https://d3js.org/d3-scale.v1.min.js');
+                                echo $this->Html->script('https://d3js.org/d3-array.v1.min.js');
+                                echo $this->Html->script('https://code.jquery.com/jquery-2.1.4.min.js');
                             ?>
                             <style>
                             .bar {
@@ -59,50 +61,56 @@ $listingFields = explode(',',$widgetData['info']['columns']);
                             }
                             </style>
                             <div id="viz_<?php echo $widgetData['slug'];?>"></div>
-
                             <script type="text/javascript">
-                                var data = <?= $this->Chart->getChartData($renderData, ['data' => $widgetData]) ?>;
+                                $(document).ready(function(){
+                                    var containerWidth = $('#viz_<?php echo $widgetData['slug'];?>').parent().parent().width();
 
-                                var margin = {top: 20, right: 20, bottom: 70, left: 40},
-                                    width = 400 - margin.left - margin.right,
-                                    height = 200 - margin.top - margin.bottom;
+                                    var data = <?= $this->Chart->getChartData($renderData, ['data' => $widgetData]) ?>;
 
-                                var x = d3.scaleBand().rangeRound([0, width]).padding(0.1),
-                                    y = d3.scaleLinear().rangeRound([height, 0]);
+                                    var margin = {top: 20, right: 20, bottom: 70, left: 40},
+                                        width = containerWidth - margin.left - margin.right,
+                                        height = 350 - margin.top - margin.bottom;
+                                    var w
+                                    var x = d3.scaleBand().rangeRound([0, width]).padding(0.1),
+                                        y = d3.scaleLinear().rangeRound([height, 0]);
 
-                                var svg = d3.select("#viz_<?php echo $widgetData['slug'];?>").append("svg")
-                                    .attr("width", width + margin.left + margin.right)
-                                    .attr("height", height + margin.top + margin.bottom);
+                                    var svg = d3.select("#viz_<?php echo $widgetData['slug'];?>").append("svg")
+                                        .attr("width", width + margin.left + margin.right)
+                                        .attr("height", height + margin.top + margin.bottom);
 
-                                var g = svg.append("g")
-                                    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+                                    var g = svg.append("g")
+                                        .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
 
-                                x.domain( data.map( function(d) { return d.x_axis; }) );
-                                y.domain( [0, d3.max(data, function(d) { return d.y_axis;}) ] );
+                                    x.domain( data.map( function(d) { return d.x_axis; }) );
+                                    // we assume its an integer scale
+                                    y.domain( [0, d3.max(data, function(d) { return parseInt(d.y_axis);}) ] );
 
-                                g.append("g")
-                                  .attr("class", "axis axis--x")
-                                  .attr("transform", "translate(0," + height + ")")
-                                  .call(d3.axisBottom(x));
+                                    g.append("g")
+                                      .attr("class", "axis axis--x")
+                                      .attr("transform", "translate(0," + height + ")")
+                                      .call(d3.axisBottom(x));
 
-                                g.append("g")
-                                    .attr('class', "axis axis--y")
-                                    .call( d3.axisLeft(y).ticks( d3.max(data, function(d) { return d.y_axis;})  ))
-                                 .append("text")
-                                    .attr('transform', 'rotate(-90)')
-                                    .attr('y', 6)
-                                    .attr('dy', '0.71em')
-                                    .attr('text-anchor', 'end')
-                                    .text('Total');
+                                    g.append("g")
+                                        .attr('class', "axis axis--y")
+                                        .call( d3.axisLeft(y).ticks(10) )
 
-                                g.selectAll('.bar')
-                                    .data(data)
-                                    .enter().append('rect')
-                                    .attr('class', 'bar')
-                                    .attr('x', function(d) { return x(d.x_axis); })
-                                    .attr('y', function(d) { return y(d.y_axis); })
-                                    .attr('width', x.bandwidth())
-                                    .attr('height', function(d){ return height - y(d.y_axis); });
+                                     .append("text")
+                                        .attr('transform', 'rotate(-90)')
+                                        .attr('y', 6)
+                                        .attr('dy', '0.71em')
+                                        .attr('text-anchor', 'end')
+                                        .text('Total');
+
+                                    g.selectAll('.bar')
+                                        .data(data)
+                                        .enter().append('rect')
+                                        .attr('class', 'bar')
+                                        .attr('x', function(d) { return x(d.x_axis); })
+                                        .attr('y', function(d) { return y(d.y_axis); })
+                                        .attr('width', x.bandwidth())
+                                        .attr('height', function(d){ return height - y(d.y_axis); });
+
+                                });
                             </script>
                         <?php endif; ?>
                     </div> <!-- panel-body -->


### PR DESCRIPTION
We scale the width of the graph based on the width of the container (refresh of the page needed).
We standardize the number of ticks per y-axis to 10 items, and properly cast in the integer for the y-axis, not to lose the min/max values.