### PR TITLE
Data validation (task #3267)

### DIFF
--- a/src/Model/Table/SavedSearchesTable.php
+++ b/src/Model/Table/SavedSearchesTable.php
@@ -635,10 +635,6 @@ class SavedSearchesTable extends Table
      */
     public function validateData($table, array $data)
     {
-        if (empty($data)) {
-            return $data;
-        }
-
         $table = $this->_getTableInstance($table);
 
         $fields = $this->getSearchableFields($table);


### PR DESCRIPTION
Is not necessary to skip data validation when passed data are empty,
since we now merge the passed data with the default ones. This fixes
invalid argument exception thrown on empty basic search.