### PR TITLE
Application widgets (task #3413)

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,5 +1,9 @@
 <?php
 use Cake\Core\Configure;
+use Cake\Event\EventManager;
+use Search\Event\WidgetsListener;
 
 // dashboards columns
 Configure::write('Search.dashboard.columns', ['Left Side', 'Right Side']);
+
+EventManager::instance()->on(new WidgetsListener());

--- a/src/Event/WidgetsListener.php
+++ b/src/Event/WidgetsListener.php
@@ -1,0 +1,133 @@
+<?php
+namespace Search\Event;
+
+use Cake\Event\Event;
+use Cake\Event\EventListenerInterface;
+use Cake\Event\EventManager;
+use Cake\ORM\TableRegistry;
+
+class WidgetsListener implements EventListenerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function implementedEvents()
+    {
+        return [
+            'Search.Dashboards.getWidgets' => [
+                'callable' => 'getWidgets',
+                'priority' => 9999999999 // this listener should be called last
+            ]
+        ];
+    }
+
+    /**
+     * Add widgets for Search plugin's Dashboards.
+     *
+     * @param \Cake\Event\Event $event Event instance
+     * @return void
+     */
+    public function getWidgets(Event $event)
+    {
+        $result = !empty($event->result) ? $event->result : [];
+
+        $savedSearches = $this->_getSavedSearches();
+        if (!empty($savedSearches)) {
+            array_push($result, ['type' => 'saved_search', 'data' => $savedSearches]);
+        }
+
+        $reports = $this->_getReports();
+        if (!empty($reports)) {
+            array_push($result, ['type' => 'report', 'data' => $reports]);
+        }
+
+        $appWidgets = $this->_getAppWidgets();
+        if (!empty($appWidgets)) {
+            array_push($result, ['type' => 'app', 'data' => $appWidgets]);
+        }
+
+        $event->result = $result;
+    }
+
+    /**
+     * Fetch all saved searches from the database.
+     *
+     * @return array
+     */
+    protected function _getSavedSearches()
+    {
+        $table = TableRegistry::get('Search.SavedSearches');
+
+        $query = $table->find('all')
+            ->where(['SavedSearches.name IS NOT' => null])
+            ->hydrate(false)
+            ->indexBy('id');
+
+        if ($query->isEmpty()) {
+            return [];
+        }
+
+        $result = $query->toArray();
+        foreach ($result as &$entity) {
+            $table = TableRegistry::get($entity['model']);
+            if (!method_exists($table, 'moduleAlias')) {
+                continue;
+            }
+            $entity['model'] = $table->moduleAlias();
+        }
+
+        return $result;
+    }
+
+    /**
+     * Fetch all reports through Event broadcast.
+     *
+     * @return array
+     */
+    protected function _getReports()
+    {
+        $event = new Event('Search.Report.getReports', $this);
+        EventManager::instance()->dispatch($event);
+
+        if (empty($event->result)) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($event->result as $model => $reports) {
+            foreach ($reports as $reportSlug => $reportInfo) {
+                $result[$reportInfo['id']] = $reportInfo;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Returns list of widgets defined in the application scope.
+     *
+     * @return array
+     */
+    protected function _getAppWidgets()
+    {
+        $table = TableRegistry::get('Search.AppWidgets');
+
+        $query = $table->find('all');
+
+        if ($query->isEmpty()) {
+            return [];
+        }
+
+        $result = [];
+        foreach ($query->toArray() as $entity) {
+            $result[] = [
+                'id' => $entity->id,
+                'model' => $entity->content['model'],
+                'name' => $entity->name,
+                'path' => $entity->content['path']
+            ];
+        }
+
+        return $result;
+    }
+}

--- a/src/Model/Table/AppWidgetsTable.php
+++ b/src/Model/Table/AppWidgetsTable.php
@@ -25,6 +25,10 @@ use Cake\Validation\Validator;
  */
 class AppWidgetsTable extends Table
 {
+    /**
+     * Widget type identifier.
+     */
+    const WIDGET_TYPE = 'app_widget';
 
     /**
      * Initialize method
@@ -163,7 +167,7 @@ class AppWidgetsTable extends Table
                 $name = Inflector::humanize($name);
                 $result[] = [
                     'name' => $name,
-                    'type' => 'app_widget',
+                    'type' => static::WIDGET_TYPE,
                     'content' => [
                         'model' => $this->alias(),
                         'path' => $path . $file,

--- a/src/Model/Table/WidgetsTable.php
+++ b/src/Model/Table/WidgetsTable.php
@@ -118,6 +118,14 @@ class WidgetsTable extends Table
 
         $widgets[] = ['type' => 'app', 'data' => $this->_getAppWidgets()];
 
+        // get widgets through Event broadcast
+        $event = new Event('Search.Dashboards.getWidgets', $this);
+        $this->eventManager()->dispatch($event);
+
+        if ($event->result) {
+            $widgets[] = $event->result;
+        }
+
         // $dashboardsTable = TableRegistry::get('Search.Dashboards');
         $savedSearchesTable = TableRegistry::get('Search.SavedSearches');
 

--- a/src/Template/Dashboards/view.ctp
+++ b/src/Template/Dashboards/view.ctp
@@ -52,9 +52,9 @@ $this->eventManager()->dispatch($event);
                         }
 
                         echo $this->element(
-                            ('app' !== $dw->widget_type ? 'Search.Widgets/' : '') . $widgetHandler->getRenderElement(),
+                            $widgetHandler->getRenderElement(),
                             ['widget' => $widgetHandler],
-                            ['plugin' => 'app' === $dw->widget_type ? false : true]
+                            ['plugin' => false]
                         );
                     } catch (\Exception $e) {
                         echo $this->element('Search.missing_element', [

--- a/src/Widgets/ReportWidget.php
+++ b/src/Widgets/ReportWidget.php
@@ -8,7 +8,7 @@ use Search\Widgets\BaseWidget;
 
 class ReportWidget extends BaseWidget
 {
-    public $renderElement = 'graph';
+    public $renderElement = 'Search.Widgets/graph';
     public $options = [];
 
     /** @const WIDGET_REPORT_SUFFIX file naming suffix of widget files */

--- a/src/Widgets/SavedSearchWidget.php
+++ b/src/Widgets/SavedSearchWidget.php
@@ -16,7 +16,7 @@ class SavedSearchWidget extends BaseWidget
 
     protected $_data = [];
 
-    public $renderElement = 'table';
+    public $renderElement = 'Search.Widgets/table';
 
     public $options = [];
 

--- a/src/Widgets/WidgetFactory.php
+++ b/src/Widgets/WidgetFactory.php
@@ -7,6 +7,7 @@ class WidgetFactory
 {
     const WIDGET_SUFFIX = 'Widget';
     const WIDGET_INTERFACE = 'WidgetInterface';
+    const APP_NAMESPACE = 'App\\Widget';
 
     /**
      * create method
@@ -23,10 +24,20 @@ class WidgetFactory
         $widget = null;
         $handlerName = Inflector::camelize($type);
 
-        $className = __NAMESPACE__ . '\\' . $handlerName . self::WIDGET_SUFFIX;
         $interface = __NAMESPACE__ . '\\' . self::WIDGET_INTERFACE;
 
-        if (!class_exists($className)) {
+        $namespaces = [static::APP_NAMESPACE, __NAMESPACE__];
+        foreach ($namespaces as $namespace) {
+            $className = $namespace . '\\' . $handlerName . self::WIDGET_SUFFIX;
+            if (!class_exists($className)) {
+                $className = null;
+                continue;
+            }
+
+            break;
+        }
+
+        if (!$className) {
             throw new \RuntimeException("Class [$type] doesn't exist");
         }
 

--- a/tests/TestCase/Model/Table/WidgetsTableTest.php
+++ b/tests/TestCase/Model/Table/WidgetsTableTest.php
@@ -1,8 +1,10 @@
 <?php
 namespace Search\Test\TestCase\Model\Table;
 
+use Cake\Event\EventManager;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Search\Event\WidgetsListener;
 use Search\Model\Table\WidgetsTable;
 
 /**
@@ -68,6 +70,8 @@ class WidgetsTableTest extends TestCase
      */
     public function testGetWidgets()
     {
+        EventManager::instance()->on(new WidgetsListener());
+
         $res = $this->Widgets->getWidgets();
         $this->assertNotEmpty($res);
         $this->assertInternalType('array', $res);

--- a/tests/TestCase/Widgets/ReportWidgetTest.php
+++ b/tests/TestCase/Widgets/ReportWidgetTest.php
@@ -54,7 +54,7 @@ class ReportWidgetTest extends TestCase
     public function testGetRenderElement()
     {
         $result = $this->widget->getRenderElement();
-        $this->assertEquals($result, 'graph');
+        $this->assertEquals($result, 'Search.Widgets/graph');
     }
 
     public function testGetReportConfigWithoutRootView()


### PR DESCRIPTION
Added support for creating application level widgets.

#### How To:
- Create the widget class under `src/Widget/` directory, for example `src/Widget/FoobarWidget.php`.
- Class name must be suffixed with `Widget` and extend `Search\Widgets\BaseWidget` class, for example:
```php
namespace App\Widget;

use Search\Widgets\BaseWidget;

class FoobarWidget extends BaseWidget
```
- Create a new Listener that listens to Event `Search.Dashboards.getWidgets`. The Event listener must return the foobar widgets in the following format:
```php
$result = !empty($event->result) ? $event->result : [];

$result[] = [
    'name' => 'Entity name',
    'id' => 'Entity id',
    'model' => 'Table Name'
];

$event->result = ['type' => 'foobar', 'data' => $result];
```