### PR TITLE
Basic search fields (task #3953)

### DIFF
--- a/src/Model/Table/SavedSearchesTable.php
+++ b/src/Model/Table/SavedSearchesTable.php
@@ -90,7 +90,7 @@ class SavedSearchesTable extends Table
      *
      * @var array
      */
-    protected $_basicSearchFieldTypes = ['string', 'text', 'textarea'];
+    protected $_basicSearchFieldTypes = ['string', 'text', 'textarea', 'related'];
 
     /**
      * Basic search default fields

--- a/src/Model/Table/SavedSearchesTable.php
+++ b/src/Model/Table/SavedSearchesTable.php
@@ -399,6 +399,11 @@ class SavedSearchesTable extends Table
     {
         // get Table instance
         $table = $this->_getTableInstance($table);
+        $tableAlias = $table->alias();
+
+        if (!empty($this->_searchableFields[$tableAlias])) {
+            return $this->_searchableFields[$tableAlias];
+        }
 
         $event = new Event('Search.Model.Search.searchabeFields', $this, [
             'table' => $table
@@ -409,9 +414,9 @@ class SavedSearchesTable extends Table
             throw new RuntimeException('Table [' . $table->registryAlias() . '] has no searchable fields defined.');
         }
 
-        $this->_searchableFields = $event->result;
+        $this->_searchableFields[$tableAlias] = $event->result;
 
-        return $this->_searchableFields;
+        return $this->_searchableFields[$tableAlias];
     }
 
     /**
@@ -807,7 +812,7 @@ class SavedSearchesTable extends Table
 
         $table = $this->_getTableInstance($model);
 
-        $this->getSearchableFields($table);
+        $searchableFields = $this->getSearchableFields($table);
 
         foreach ($data['criteria'] as $fieldName => $criterias) {
             if (empty($criterias)) {
@@ -821,14 +826,14 @@ class SavedSearchesTable extends Table
                     continue;
                 }
                 $operator = $criteria['operator'];
-                if (isset($this->_searchableFields[$fieldName]['operators'][$operator]['pattern'])) {
+                if (isset($searchableFields[$fieldName]['operators'][$operator]['pattern'])) {
                     $value = str_replace(
                         '{{value}}',
                         $value,
-                        $this->_searchableFields[$fieldName]['operators'][$operator]['pattern']
+                        $searchableFields[$fieldName]['operators'][$operator]['pattern']
                     );
                 }
-                $sqlOperator = $this->_searchableFields[$fieldName]['operators'][$operator]['operator'];
+                $sqlOperator = $searchableFields[$fieldName]['operators'][$operator]['operator'];
                 $key = $table->aliasField($fieldName) . ' ' . $sqlOperator;
 
                 if (!array_key_exists($key, $result)) {

--- a/src/Model/Table/SavedSearchesTable.php
+++ b/src/Model/Table/SavedSearchesTable.php
@@ -514,13 +514,10 @@ class SavedSearchesTable extends Table
         // get Table instance
         $table = $this->_getTableInstance($table);
 
-        $fields = $this->_getBasicSearchFields($table);
-        if (empty($fields)) {
-            return $result;
-        }
-
         $searchableFields = $this->getSearchableFields($table);
-        if (empty($searchableFields)) {
+
+        $fields = $this->_getBasicSearchFields($table, $searchableFields);
+        if (empty($fields)) {
             return $result;
         }
 
@@ -600,9 +597,10 @@ class SavedSearchesTable extends Table
      * using the ones that their type matches the _basicSearchFieldTypes list.
      *
      * @param \Cake\ORM\Table $table Table instance
+     * @param array $searchableFields Searchable fields
      * @return array
      */
-    protected function _getBasicSearchFields(Table $table)
+    protected function _getBasicSearchFields(Table $table, array $searchableFields = [])
     {
         $event = new Event('Search.Model.Search.basicSearchFields', $this, [
             'table' => $table
@@ -630,9 +628,8 @@ class SavedSearchesTable extends Table
             return $result;
         }
 
-        $searchableFields = $this->getSearchableFields($table);
         if (empty($searchableFields)) {
-            return $result;
+            $searchableFields = $this->getSearchableFields($table);
         }
 
         foreach ($searchableFields as $field => $properties) {

--- a/src/Model/Table/SavedSearchesTable.php
+++ b/src/Model/Table/SavedSearchesTable.php
@@ -526,6 +526,10 @@ class SavedSearchesTable extends Table
                 continue;
             }
 
+            if (!in_array($searchableFields[$field]['type'], $this->_basicSearchFieldTypes)) {
+                continue;
+            }
+
             $type = $searchableFields[$field]['type'];
             $operator = key($searchableFields[$field]['operators']);
             $value = $data['query'];

--- a/src/Model/Table/SavedSearchesTable.php
+++ b/src/Model/Table/SavedSearchesTable.php
@@ -90,7 +90,7 @@ class SavedSearchesTable extends Table
      *
      * @var array
      */
-    protected $_basicSearchFieldTypes = ['string', 'text', 'textarea', 'related'];
+    protected $_basicSearchFieldTypes = ['string', 'text', 'textarea', 'related', 'email', 'url', 'phone'];
 
     /**
      * Basic search default fields


### PR DESCRIPTION
- Filter out basic search fields types, such as `date`, `time`, `datetime`, `list` etc.
- Cache searchable fields by table into a class property, for performance optimization.