### PR TITLE
Event names enumeration (task #4352)

### DIFF
--- a/src/Event/EventName.php
+++ b/src/Event/EventName.php
@@ -1,0 +1,12 @@
+<?php
+namespace Search\Event;
+
+use MyCLabs\Enum\Enum;
+
+/**
+ * Event Name enum
+ */
+class EventName extends Enum
+{
+    const MODEL_DASHBOARDS_GET_WIDGETS = 'Search.Dashboards.getWidgets';
+}

--- a/src/Event/Model/WidgetsListener.php
+++ b/src/Event/Model/WidgetsListener.php
@@ -5,6 +5,7 @@ use Cake\Event\Event;
 use Cake\Event\EventListenerInterface;
 use Cake\Event\EventManager;
 use Cake\ORM\TableRegistry;
+use Search\Event\EventName;
 
 class WidgetsListener implements EventListenerInterface
 {
@@ -14,7 +15,7 @@ class WidgetsListener implements EventListenerInterface
     public function implementedEvents()
     {
         return [
-            'Search.Dashboards.getWidgets' => [
+            (string)EventName::MODEL_DASHBOARDS_GET_WIDGETS() => [
                 'callable' => 'getWidgets',
                 'priority' => 9999999999 // this listener should be called last
             ]

--- a/src/Model/Table/WidgetsTable.php
+++ b/src/Model/Table/WidgetsTable.php
@@ -12,6 +12,7 @@ use Cake\ORM\TableRegistry;
 use Cake\Utility\Inflector;
 use Cake\Utility\Text;
 use Cake\Validation\Validator;
+use Search\Event\EventName;
 
 /**
  * Widgets Model
@@ -116,7 +117,7 @@ class WidgetsTable extends Table
     public function getWidgets()
     {
         // get widgets through Event broadcast
-        $event = new Event('Search.Dashboards.getWidgets', $this);
+        $event = new Event((string)EventName::MODEL_DASHBOARDS_GET_WIDGETS(), $this);
         $this->eventManager()->dispatch($event);
 
         $widgets = !empty($event->result) ? $event->result : [];


### PR DESCRIPTION
Use [php-enum](https://github.com/myclabs/php-enum) library to define event names enum. Modified all events to use `EventName` enumeration class.