### PR TITLE
Event names enumeration (task #4352)

### DIFF
--- a/src/Controller/SearchTrait.php
+++ b/src/Controller/SearchTrait.php
@@ -6,7 +6,7 @@ use Cake\Filesystem\File;
 use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
-use Search\Event\EventName;
+use Search\Event\EventName as SearchEventName;
 use Search\Utility;
 use Zend\Diactoros\Stream;
 
@@ -119,7 +119,7 @@ trait SearchTrait
 
         $query = $searchTable->search($table, $this->Auth->user(), $searchData);
 
-        $event = new Event((string)EventName::MODEL_SEARCH_AFTER_FIND(), $this, [
+        $event = new Event((string)SearchEventName::MODEL_SEARCH_AFTER_FIND(), $this, [
             'entities' => $this->paginate($query),
             'table' => $table
         ]);
@@ -276,7 +276,7 @@ trait SearchTrait
         // execute search
         $entities = $searchTable->search($table, $this->Auth->user(), $searchData)->all();
 
-        $event = new Event((string)EventName::MODEL_SEARCH_AFTER_FIND(), $this, [
+        $event = new Event((string)SearchEventName::MODEL_SEARCH_AFTER_FIND(), $this, [
             'entities' => $entities,
             'table' => $table
         ]);

--- a/src/Controller/SearchTrait.php
+++ b/src/Controller/SearchTrait.php
@@ -6,6 +6,7 @@ use Cake\Filesystem\File;
 use Cake\Network\Exception\BadRequestException;
 use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
+use Search\Event\EventName;
 use Search\Utility;
 use Zend\Diactoros\Stream;
 
@@ -118,7 +119,7 @@ trait SearchTrait
 
         $query = $searchTable->search($table, $this->Auth->user(), $searchData);
 
-        $event = new Event('Search.Model.Search.afterFind', $this, [
+        $event = new Event((string)EventName::MODEL_SEARCH_AFTER_FIND(), $this, [
             'entities' => $this->paginate($query),
             'table' => $table
         ]);
@@ -275,7 +276,7 @@ trait SearchTrait
         // execute search
         $entities = $searchTable->search($table, $this->Auth->user(), $searchData)->all();
 
-        $event = new Event('Search.Model.Search.afterFind', $this, [
+        $event = new Event((string)EventName::MODEL_SEARCH_AFTER_FIND(), $this, [
             'entities' => $entities,
             'table' => $table
         ]);

--- a/src/Event/EventName.php
+++ b/src/Event/EventName.php
@@ -8,5 +8,15 @@ use MyCLabs\Enum\Enum;
  */
 class EventName extends Enum
 {
+    const MENU_ACTIONS_SEARCH_VIEW = 'Search.View.View.Menu.Actions';
+    const MENU_TOP_DASHBOARD_VIEW = 'Search.Dashboards.View.View.Menu.Top';
+
+    const MODEL_DASHBOARDS_GET_REPORTS = 'Search.Report.getReports';
     const MODEL_DASHBOARDS_GET_WIDGETS = 'Search.Dashboards.getWidgets';
+    const MODEL_SEARCH_AFTER_FIND = 'Search.Model.Search.afterFind';
+    const MODEL_SEARCH_BASIC_SEARCH_FIELDS = 'Search.Model.Search.basicSearchFields';
+    const MODEL_SEARCH_DISPLAY_FIELDS = 'Search.Model.Search.displayFields';
+    const MODEL_SEARCH_SEARCHABLE_FIELDS = 'Search.Model.Search.searchabeFields';
+
+    const VIEW_DASHBOARDS_WIDGET_GRID = 'Search.Dashboard.Widget.GridElement';
 }

--- a/src/Event/Model/WidgetsListener.php
+++ b/src/Event/Model/WidgetsListener.php
@@ -103,7 +103,7 @@ class WidgetsListener implements EventListenerInterface
      */
     protected function _getReports()
     {
-        $event = new Event('Search.Report.getReports', $this);
+        $event = new Event((string)EventName::MODEL_DASHBOARDS_GET_REPORTS(), $this);
         EventManager::instance()->dispatch($event);
 
         if (empty($event->result)) {

--- a/src/Model/Table/SavedSearchesTable.php
+++ b/src/Model/Table/SavedSearchesTable.php
@@ -14,6 +14,7 @@ use Cake\Utility\Inflector;
 use Cake\Validation\Validator;
 use InvalidArgumentException;
 use Qobo\Utils\ModuleConfig\ModuleConfig;
+use Search\Event\EventName;
 use Search\Model\Entity\SavedSearch;
 use Search\Utility;
 
@@ -485,7 +486,7 @@ class SavedSearchesTable extends Table
         }
 
         if (empty($result)) {
-            $event = new Event('Search.Model.Search.displayFields', $this, [
+            $event = new Event((string)EventName::MODEL_SEARCH_DISPLAY_FIELDS(), $this, [
                 'table' => $table
             ]);
             $this->eventManager()->dispatch($event);
@@ -695,7 +696,7 @@ class SavedSearchesTable extends Table
             throw new InvalidArgumentException($msg);
         }
 
-        $event = new Event('Search.Model.Search.basicSearchFields', $this, [
+        $event = new Event((string)EventName::MODEL_SEARCH_BASIC_SEARCH_FIELDS(), $this, [
             'table' => $table
         ]);
         $this->eventManager()->dispatch($event);

--- a/src/Template/Dashboards/view.ctp
+++ b/src/Template/Dashboards/view.ctp
@@ -1,13 +1,13 @@
 <?php
-
 use Cake\Event\Event;
 use Cake\Log\LogTrait;
+use Search\Event\EventName;
 use Search\Widgets\WidgetFactory;
 
 $scripts = [];
 $chartData = [];
 
-$event = new Event('Search.Dashboards.View.View.Menu.Top', $this, [
+$event = new Event((string)EventName::MENU_TOP_DASHBOARD_VIEW(), $this, [
     'request' => $this->request,
     $dashboard
 ]);

--- a/src/Template/Element/Widgets/grid.ctp
+++ b/src/Template/Element/Widgets/grid.ctp
@@ -1,6 +1,7 @@
 <?php
 use Cake\Event\Event;
 use Cake\Utility\Inflector;
+use Search\Event\EventName;
 
 $config = $widget->getConfig();
 $data = $widget->getData();
@@ -42,7 +43,7 @@ echo $this->Html->script('Search.grid_report', ['block' => 'scriptBotton']);
                     <?php foreach ($columns as $col) : ?>
                         <?php
                             $_col = preg_replace('/_/', '', $col);
-                            $event = new Event('Search.Dashboard.Widget.GridElement', $this, [
+                            $event = new Event((string)EventName::VIEW_DASHBOARDS_WIDGET_GRID(), $this, [
                                 'model' => $config['modelName'],
                                 'field' => $_col,
                                 'value' => $item[$col],
@@ -51,19 +52,19 @@ echo $this->Html->script('Search.grid_report', ['block' => 'scriptBotton']);
                             $this->eventManager()->dispatch($event);
                         ?>
                         <td><?= !empty($event->result) ? $event->result : $item[$col] ?></td>
-                    <?php endforeach; ?>                    
+                    <?php endforeach; ?>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>
                 <tfoot>
-                    <tr>                        
+                    <tr>
                         <?php foreach ($columns as $col) : ?>
                             <th class="<?= in_array($col, $totals) ? 'sum' : 'normal'; ?>"></th>
                         <?php endforeach; ?>
                     </tr>
                 </tfoot>
                 </table>
-            </div> 
+            </div>
         </div>
     </div>
 </div>

--- a/src/Utility.php
+++ b/src/Utility.php
@@ -7,6 +7,7 @@ use Cake\ORM\ResultSet;
 use Cake\ORM\Table;
 use Cake\Utility\Inflector;
 use Cake\View\View;
+use Search\Event\EventName;
 
 class Utility
 {
@@ -82,7 +83,7 @@ class Utility
      */
     protected function _getSearchableFields(Table $table, array $user)
     {
-        $event = new Event('Search.Model.Search.searchabeFields', $this, [
+        $event = new Event((string)EventName::MODEL_SEARCH_SEARCHABLE_FIELDS(), $this, [
             'table' => $table,
             'user' => $user
         ]);
@@ -165,7 +166,7 @@ class Utility
                 $result[$key][] = $entity->_matchingData[$tableName]->get($field);
             }
 
-            $event = new Event('Search.View.View.Menu.Actions', new View(), [
+            $event = new Event((string)EventName::MENU_ACTIONS_SEARCH_VIEW(), new View(), [
                 'entity' => $entity,
                 'model' => $registryAlias
             ]);

--- a/src/Widgets/ReportWidget.php
+++ b/src/Widgets/ReportWidget.php
@@ -4,6 +4,7 @@ namespace Search\Widgets;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
 use Cake\Utility\Inflector;
+use Search\Event\EventName;
 use Search\Widgets\BaseWidget;
 
 class ReportWidget extends BaseWidget
@@ -84,7 +85,7 @@ class ReportWidget extends BaseWidget
             return $result;
         }
 
-        $event = new Event('Search.Report.getReports', $options['rootView']->request);
+        $event = new Event((string)EventName::MODEL_DASHBOARDS_GET_REPORTS(), $options['rootView']->request);
         $options['rootView']->EventManager()->dispatch($event);
 
         $result = $event->result;


### PR DESCRIPTION
Use [php-enum](https://github.com/myclabs/php-enum) library to define event names enum. Modified all events to use `EventName` enumeration class.