### PR TITLE
Adding API token for being used in api calls (task #4543)

### DIFF
--- a/src/Template/Element/Search/results.ctp
+++ b/src/Template/Element/Search/results.ctp
@@ -71,7 +71,7 @@ foreach ($searchData['display_columns'] as $field) {
 $options['columns'][] = ['name' => 'actions'];
 
 echo $this->Html->scriptBlock(
-    'view_search_result.init(' . json_encode($options) . ');',
+    'view_search_result.init(' . json_encode($options) . '); api_options = {"token": "' . Configure::read('Search.api.token') . '"};',
     ['block' => 'scriptBottom']
 );
 echo $this->Html->css('Search.search-datatables', ['block' => 'css']);


### PR DESCRIPTION
In case `VIEW_SEARCH_ACTIONS` event broadcasted would need to fire some AJAX calls, we add `api_options.token` variable in to the body of the page.