### PR TITLE
Updated to cakephp-plugin-template v4.1.0

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,6 +9,7 @@ engines:
 exclude_paths:
 - config/
 - tests/
+- webroot/plugins/
 ratings:
   paths:
   - "src/**/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - nightly
 
 env:
@@ -19,9 +20,11 @@ env:
 matrix:
   fast_finish: true
   allow_failures:
+    - php: 7.2
     - php: nightly
 
 install:
+  - composer validate --strict
   - composer install --no-interaction --no-progress --no-suggest
   - mkdir -p build/logs
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2013-2017 Qobo Ltd (https://www.qobo.biz)
+Copyright (c) 2013-2018 Qobo Ltd (https://www.qobo.biz)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated to [cakephp-plugin-template v4.1.0](https://github.com/QoboLtd/cakephp-plugin-template/releases/tag/v4.1.0).