### PR TITLE
Widget active tab fix (task #5173)

### DIFF
--- a/src/Template/Cell/Result/widget.ctp
+++ b/src/Template/Cell/Result/widget.ctp
@@ -59,7 +59,7 @@ echo $cakeView->Html->scriptBlock('new DataTablesInit(' . json_encode($dtOptions
 ?>
 <div class="dashboard-widget-saved-search nav-tabs-custom">
     <ul class="nav nav-tabs pull-right" id="widget-<?= md5(implode('', $viewOptions['url'])) ?>">
-        <li>
+        <li class="<?= ! $isGroup ? 'active' : '' ?>">
             <a href="#table_<?= $tableOptions['id'] ?>" data-toggle="tab" aria-expanded="true">
                 <i class="fa fa-table"></i>
             </a>
@@ -76,7 +76,7 @@ echo $cakeView->Html->scriptBlock('new DataTablesInit(' . json_encode($dtOptions
         <li class="pull-left header"><?= $this->Html->link($viewOptions['title'], $viewOptions['url']) ?></li>
     </ul>
     <div class="tab-content">
-        <div id="table_<?= $tableOptions['id'] ?>" class="tab-pane">
+        <div id="table_<?= $tableOptions['id'] ?>" class="tab-pane <?= ! $isGroup ? 'active' : '' ?>">
             <div class="table-responsive">
                 <?php if ($isExport) : ?>
                     <?= $this->Html->link(__('Export'), $viewOptions['exportUrl'], ['class' => 'dt-button pull-right']) ?>
@@ -87,7 +87,7 @@ echo $cakeView->Html->scriptBlock('new DataTablesInit(' . json_encode($dtOptions
                         <?php foreach ($tableOptions['headers'] as $header) : ?>
                             <th><?= $header ?></th>
                         <?php endforeach; ?>
-                        <?php if (!$isGroup) : ?>
+                        <?php if (! $isGroup) : ?>
                             <th class="actions"><?= __('Actions') ?></th>
                         <?php endif; ?>
                         </tr>

--- a/tests/Fixture/WidgetsFixture.php
+++ b/tests/Fixture/WidgetsFixture.php
@@ -108,5 +108,17 @@ class WidgetsFixture extends TestFixture
             'modified' => '2016-10-19 12:08:59',
             'trashed' => null
         ],
+        [
+            'id' => '00000000-0000-0000-0000-000000000006',
+            'dashboard_id' => '00000000-0000-0000-0000-000000000004',
+            'widget_id' => '00000000-0000-0000-0000-000000000005',
+            'widget_type' => 'saved_search',
+            'widget_options' => '{"i":"0","h":2,"w":6,"x":6,"y":2,"id":"00000000-0000-0000-0000-000000000002","type":"saved_search"}',
+            'column' => 0,
+            'row' => 3,
+            'created' => '2016-10-19 12:08:59',
+            'modified' => '2016-10-19 12:08:59',
+            'trashed' => null
+        ],
     ];
 }

--- a/tests/TestCase/Controller/DashboardsControllerTest.php
+++ b/tests/TestCase/Controller/DashboardsControllerTest.php
@@ -136,6 +136,7 @@ class DashboardsControllerTest extends IntegrationTestCase
         $this->assertResponseContains('<table');
         $this->assertResponseContains('<th>Name</th>');
         $this->assertResponseContains('<th class="actions">Actions</th>');
+        $this->assertResponseContains('<li class="active">');
     }
 
     public function testAdd()

--- a/tests/TestCase/Controller/DashboardsControllerTest.php
+++ b/tests/TestCase/Controller/DashboardsControllerTest.php
@@ -122,7 +122,7 @@ class DashboardsControllerTest extends IntegrationTestCase
         $this->assertResponseContains('<h4>Everyone Dashboard</h4>');
     }
 
-    public function testViewAdminUserWithHtmlTable()
+    public function testViewWithSavedSearch()
     {
         // admin user
         $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000002']);
@@ -136,7 +136,23 @@ class DashboardsControllerTest extends IntegrationTestCase
         $this->assertResponseContains('<table');
         $this->assertResponseContains('<th>Name</th>');
         $this->assertResponseContains('<th class="actions">Actions</th>');
-        $this->assertResponseContains('<li class="active">');
+        $this->assertResponseContains('<li class="active"');
+    }
+
+    public function testViewWithGroupBySavedSearch()
+    {
+        // admin user
+        $this->session(['Auth.User.id' => '00000000-0000-0000-0000-000000000002']);
+
+        $this->get('/search/dashboards/view/00000000-0000-0000-0000-000000000004');
+
+        $this->assertResponseOk();
+
+        $this->assertResponseContains('#funnel_chart_table');
+        $this->assertResponseContains('#donut_chart_table');
+        $this->assertResponseContains('#bar_chart_table');
+        $this->assertResponseContains('<li class="active"');
+        $this->assertResponseContains('class="tab-pane active"');
     }
 
     public function testAdd()

--- a/tests/TestCase/Widgets/ReportWidgetTest.php
+++ b/tests/TestCase/Widgets/ReportWidgetTest.php
@@ -345,7 +345,7 @@ class ReportWidgetTest extends TestCase
     public function getQueriesList()
     {
         return [
-            ['SELECT id,created FROM widgets LIMIT 10', 5],
+            ['SELECT id,created FROM widgets LIMIT 10', 6],
             ['SELECT id,created FROM widgets WHERE id = 1', 0],
         ];
     }


### PR DESCRIPTION
Sets table tab as `active` if no charts are available.