### PR TITLE
Fixing exceptions within dashboards (task #5333)

### DIFF
--- a/src/Template/Dashboards/view.ctp
+++ b/src/Template/Dashboards/view.ctp
@@ -56,11 +56,17 @@ $chartData = [];
                     $scripts[] = $dataOptions['scripts'];
                 }
 
-                echo $this->element(
+                $widgetContent = $this->element(
                     $widgetHandler->getRenderElement(),
                     ['widget' => $widgetHandler],
                     ['plugin' => false]
                 );
+
+                if (empty($widgetContent))  {
+                    throw new \Exception(__('Widget is unavailable'));
+                }
+                echo $widgetContent;
+
             } catch (\Exception $e) {
                 $this->log("Cannot process widget: " . $e->getMessage(), 'error');
                 echo $this->element('Search.missing_element', [

--- a/src/Template/Dashboards/view.ctp
+++ b/src/Template/Dashboards/view.ctp
@@ -62,11 +62,10 @@ $chartData = [];
                     ['plugin' => false]
                 );
 
-                if (empty($widgetContent))  {
+                if (empty($widgetContent)) {
                     throw new \Exception(__('Widget is unavailable'));
                 }
                 echo $widgetContent;
-
             } catch (\Exception $e) {
                 $this->log("Cannot process widget: " . $e->getMessage(), 'error');
                 echo $this->element('Search.missing_element', [

--- a/src/Template/Element/Widgets/table.ctp
+++ b/src/Template/Element/Widgets/table.ctp
@@ -9,9 +9,12 @@
  * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
  * @license       https://opensource.org/licenses/mit-license.php MIT License
  */
-
 $savedSearch = $widget->getData();
 $widgetOptions = $widget->getOptions();
+
+if (empty($savedSearch)) {
+    return '';
+}
 
 $args = [
     [

--- a/src/Widgets/SavedSearchWidget.php
+++ b/src/Widgets/SavedSearchWidget.php
@@ -93,6 +93,7 @@ class SavedSearchWidget extends BaseWidget
             $query = $this->_tableInstance->findById($this->_entity->widget_id);
             if ($query->isEmpty()) {
                 $this->errors[] = 'No data found for this entity';
+
                 return $savedSearch;
             }
             $savedSearch = $query->first();

--- a/src/Widgets/SavedSearchWidget.php
+++ b/src/Widgets/SavedSearchWidget.php
@@ -92,6 +92,7 @@ class SavedSearchWidget extends BaseWidget
         try {
             $query = $this->_tableInstance->findById($this->_entity->widget_id);
             if ($query->isEmpty()) {
+                $this->errors[] = 'No data found for this entity';
                 return $savedSearch;
             }
             $savedSearch = $query->first();


### PR DESCRIPTION
Whenever the exception is thrown within the widget
element, the layout breaks due to buffer output.

We simply return an empty string to assuming
something went wrong and throw an exception
from the Dashboards/view.ctp