### PR TITLE
Magic values support (task #4569)

### DIFF
--- a/src/Template/Element/Search/filters.ctp
+++ b/src/Template/Element/Search/filters.ctp
@@ -73,6 +73,16 @@ if (!empty($searchData['criteria'])) {
                 }
                 ksort($selectOptions);
 
+                // push current model fields to the top of the filters list
+                foreach ($selectOptions as $k => $v) {
+                    if ($k !== $this->name) {
+                        continue;
+                    }
+
+                    $selectOptions = array_merge($v, $selectOptions);
+                    unset($selectOptions[$k]);
+                }
+
                 echo $this->Form->select(
                     'fields',
                     array_merge(['' => __('-- Add filter --')], $selectOptions),

--- a/src/Utility/MagicValue.php
+++ b/src/Utility/MagicValue.php
@@ -12,6 +12,7 @@
 namespace Search\Utility;
 
 use Cake\I18n\Time;
+use InvalidArgumentException;
 
 /**
  * Class responsible for generating Magic values.

--- a/src/Utility/MagicValue.php
+++ b/src/Utility/MagicValue.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ *
+ * Licensed under The MIT License
+ * For full copyright and license information, please see the LICENSE
+ * Redistributions of files must retain the above copyright notice.
+ *
+ * @copyright     Copyright (c) Qobo Ltd. (https://www.qobo.biz)
+ * @license       https://opensource.org/licenses/mit-license.php MIT License
+ */
+namespace Search\Utility;
+
+use Cake\I18n\Time;
+
+/**
+ * Class responsible for generating Magic values.
+ */
+final class MagicValue
+{
+    /**
+     * Magic value wrapper identifier.
+     */
+    const WRAPPER = '%%';
+
+    /**
+     * User info.
+     *
+     * @var array
+     */
+    private $user = [];
+
+    /**
+     * Field value.
+     *
+     * @var string
+     */
+    private $value = '';
+
+    /**
+     * Constructor method.
+     *
+     * @param string $value Field value
+     * @param array $user User info
+     * @return void
+     */
+    public function __construct($value, array $user)
+    {
+        if (empty($user)) {
+            throw new InvalidArgumentException('User info are required.');
+        }
+
+        if (! is_string($value)) {
+            throw new InvalidArgumentException('Value must be a string.');
+        }
+
+        $this->user = $user;
+        $this->value = $value;
+    }
+
+    /**
+     * Magic value getter.
+     *
+     * @return mixed
+     */
+    public function get()
+    {
+        $value = str_replace(static::WRAPPER, '', $this->value);
+
+        if (! method_exists($this, $value)) {
+            return $this->value;
+        }
+
+        return $this->{$value}();
+    }
+
+    /**
+     * Current user id magic value getter.
+     *
+     * @return string
+     */
+    private function me()
+    {
+        return $this->user['id'];
+    }
+
+    /**
+     * Today's date magic value getter.
+     *
+     * @return \Cake\I18n\Time
+     */
+    private function today()
+    {
+        return new Time('today');
+    }
+
+    /**
+     * Yesterday's date magic value getter.
+     *
+     * @return \Cake\I18n\Time
+     */
+    private function yesterday()
+    {
+        return new Time('yesterday');
+    }
+    /**
+     * Tomorrow's date magic value getter.
+     *
+     * @return \Cake\I18n\Time
+     */
+    private function tomorrow()
+    {
+        return new Time('tomorrow');
+    }
+}

--- a/src/Utility/Search.php
+++ b/src/Utility/Search.php
@@ -22,6 +22,7 @@ use Search\Event\EventName;
 use Search\Model\Entity\SavedSearch;
 use Search\Utility;
 use Search\Utility\BasicSearch;
+use Search\Utility\MagicValue;
 use Search\Utility\Options;
 use Search\Utility\Validator;
 
@@ -348,8 +349,8 @@ class Search
             return $this->getEmptyWhereCondition($field, $criteria);
         }
 
+        $value = $this->handleMagicValue($value);
         $operator = $this->searchFields[$field]['operators'][$criteria['operator']];
-
         $key = $field . ' ' . $operator['operator'];
 
         if (isset($operator['pattern'])) {
@@ -360,6 +361,29 @@ class Search
         $result = [$key => $value];
 
         return $result;
+    }
+
+    /**
+     * Magic value handler.
+     *
+     * @param mixed $value Field value
+     * @return mixed
+     */
+    protected function handleMagicValue($value)
+    {
+        switch (gettype($value)) {
+            case 'string':
+                $value = (new MagicValue($value, $this->user))->get();
+                break;
+
+            case 'array':
+                foreach ($value as $key => $val) {
+                    $value[$key] = (new MagicValue($val, $this->user))->get();
+                }
+                break;
+        }
+
+        return $value;
     }
 
     /**

--- a/tests/TestCase/Utility/MagicValueTest.php
+++ b/tests/TestCase/Utility/MagicValueTest.php
@@ -1,0 +1,59 @@
+<?php
+namespace Search\Utility;
+
+use Cake\I18n\Time;
+use Cake\TestSuite\TestCase;
+use InvalidArgumentException;
+use Search\Utility\MagicValue;
+
+/**
+ * Search\Utility\MagicValue Test Case
+ */
+class MagicValueTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->user = ['id' => '00000000-0000-0000-0000-000000000002'];
+    }
+
+    public function tearDown()
+    {
+        unset($this->user);
+
+        parent::tearDown();
+    }
+
+    public function testConstructor()
+    {
+        new MagicValue('foo', $this->user);
+    }
+
+    public function testConstructorExceptionInvalidValue()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new MagicValue([], $this->user);
+    }
+
+    public function testConstructorExceptionInvalidUserInfo()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        new MagicValue('foo', []);
+    }
+
+    public function testGetWithoutMagicValue()
+    {
+        $this->assertEquals('%%foo%%', (new MagicValue('%%foo%%', $this->user))->get());
+    }
+
+    public function testGetWithMagicValue()
+    {
+        $this->assertEquals('00000000-0000-0000-0000-000000000002', (new MagicValue('%%me%%', $this->user))->get());
+        $this->assertInstanceOf(Time::class, (new MagicValue('%%today%%', $this->user))->get());
+        $this->assertInstanceOf(Time::class, (new MagicValue('%%yesterday%%', $this->user))->get());
+        $this->assertInstanceOf(Time::class, (new MagicValue('%%tomorrow%%', $this->user))->get());
+    }
+}

--- a/tests/TestCase/Utility/SearchTest.php
+++ b/tests/TestCase/Utility/SearchTest.php
@@ -369,6 +369,23 @@ class SearchTest extends TestCase
         $this->assertEquals(1, $result->count());
     }
 
+    public function testExecuteWithRelatedValueArray()
+    {
+        $model = 'Dashboards';
+
+        $data = [
+            'criteria' => [
+                $model . '.role_id' => [
+                    10 => ['type' => 'related', 'operator' => 'is', 'value' => ['00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002']]
+                ]
+            ]
+        ];
+
+        $result = $this->Search->execute($data);
+
+        $this->assertEquals(2, $result->count());
+    }
+
     public function testCreate()
     {
         $data = [


### PR DESCRIPTION
Added functionality for handling magic values when generating search where clause conditions.

Requires merge and release of: https://github.com/QoboLtd/cakephp-csv-migrations/pull/553