### PR TITLE
Use Comparison class (task #2555)

### DIFF
--- a/src/Utility/Search.php
+++ b/src/Utility/Search.php
@@ -358,15 +358,15 @@ class Search
 
         $value = $this->handleMagicValue($value);
         $operator = $this->searchFields[$field]['operators'][$criteria['operator']];
-        $type = empty($this->searchFields[$field]['type']) ? 'string' : $this->searchFields[$field]['type'];
 
         if (isset($operator['pattern'])) {
             $pattern = $operator['pattern'];
             $value = str_replace('{{value}}', $value, $pattern);
         }
 
-        if ($type === 'related') {
-            $type = 'string';
+        $type = 'string';
+        if (!empty($this->searchFields[$field]['type']) && $this->searchFields[$field]['type'] !== 'related') {
+            $type = $this->searchFields[$field]['type'];
         }
 
         if (in_array($operator['operator'], ['IN', 'NOT IN'])) {

--- a/src/Utility/Search.php
+++ b/src/Utility/Search.php
@@ -358,14 +358,23 @@ class Search
 
         $value = $this->handleMagicValue($value);
         $operator = $this->searchFields[$field]['operators'][$criteria['operator']];
-        $key = $field . ' ' . $operator['operator'];
+        $type = empty($this->searchFields[$field]['type']) ? 'string' : $this->searchFields[$field]['type'];
 
         if (isset($operator['pattern'])) {
             $pattern = $operator['pattern'];
             $value = str_replace('{{value}}', $value, $pattern);
         }
 
-        return [ new Comparison(new IdentifierExpression($field), $value, 'string', $operator['operator']) ];
+        if ($type === 'related') {
+            $type = 'string';
+        }
+
+        if (in_array($operator['operator'], ['IN', 'NOT IN'])) {
+            $type .= '[]';
+            $value = (array)$value;
+        }
+
+        return [ new Comparison(new IdentifierExpression($field), $value, $type, $operator['operator']) ];
     }
 
     /**

--- a/src/Utility/Search.php
+++ b/src/Utility/Search.php
@@ -11,6 +11,8 @@
  */
 namespace Search\Utility;
 
+use Cake\Database\Expression\Comparison;
+use Cake\Database\Expression\IdentifierExpression;
 use Cake\Datasource\QueryInterface;
 use Cake\Datasource\RepositoryInterface;
 use Cake\Event\Event;
@@ -363,9 +365,7 @@ class Search
             $value = str_replace('{{value}}', $value, $pattern);
         }
 
-        $result = [$key => $value];
-
-        return $result;
+        return [ new Comparison(new IdentifierExpression($field), $value, 'string', $operator['operator']) ];
     }
 
     /**

--- a/tests/TestCase/Utility/SearchTest.php
+++ b/tests/TestCase/Utility/SearchTest.php
@@ -357,7 +357,7 @@ class SearchTest extends TestCase
         ];
 
         $result = $this->Search->execute($data);
-
+// ($result->sql());
         $this->assertEquals(2, $result->count());
     }
 

--- a/tests/TestCase/Utility/SearchTest.php
+++ b/tests/TestCase/Utility/SearchTest.php
@@ -357,7 +357,6 @@ class SearchTest extends TestCase
         ];
 
         $result = $this->Search->execute($data);
-// ($result->sql());
         $this->assertEquals(2, $result->count());
     }
 


### PR DESCRIPTION
This PR attempts to introduce changes so that Search plugin is compatible with Trash Behavior plugin. In short, replaces where clauses in an array format with instances of `Comparison` class.

Trash Behavior plugin wont add any conditions for the `trashed` field, when the `trashed` field is already included in the where clause. However, this feature does not fully support conditions in array format. As the result, the extra conditions are being added causing the query to return invalid results.