### PR TITLE
Include NULL results (task #9978)

### DIFF
--- a/src/Utility/Search.php
+++ b/src/Utility/Search.php
@@ -427,6 +427,10 @@ class Search
             $value = (array)$value;
         }
 
+        if ($operator['operator'] === 'NOT IN') {
+            return [ 'OR' => [ $field . ' IS NULL', new Comparison(new IdentifierExpression($field), $value, $type, $operator['operator']) ]];
+        }
+
         return [ new Comparison(new IdentifierExpression($field), $value, $type, $operator['operator']) ];
     }
 

--- a/tests/TestCase/Utility/SearchTest.php
+++ b/tests/TestCase/Utility/SearchTest.php
@@ -397,7 +397,7 @@ class SearchTest extends TestCase
 
         $result = $this->Search->execute($data);
 
-        $this->assertEquals(1, $result->count());
+        $this->assertEquals(2, $result->count());
     }
 
     public function testExecuteWithRelatedValueArray(): void


### PR DESCRIPTION
This will solve the issue to not have the null entities when we use the `IS NOT` filter.