### PR TITLE
Add JavaScript fix (task #10430)

### DIFF
--- a/webroot/js/reportGraphs.js
+++ b/webroot/js/reportGraphs.js
@@ -171,6 +171,9 @@
 
     var charts = [];
     window.chartsData.forEach(function (data) {
+        if ( typeof data.options == 'undefined') {
+            return;
+        }
         var id = data.options.element;
         var isVisible = (!$('a[href="#' + id + '"]').data('toggle') || $('#' + id).hasClass('active'));
 

--- a/webroot/plugins/qobo.grid.js
+++ b/webroot/plugins/qobo.grid.js
@@ -89,12 +89,11 @@ new Vue({
             let types = [];
             let models = [];
             $.ajax({
-                type: 'post',
+                type: 'get',
                 dataType: 'json',
                 url: '/search/widgets/index',
                 headers: {
                     'Authorization': 'Bearer ' + this.token,
-                    'X-CSRF-Token': document.cookie.match(new RegExp('csrfToken=([^;]+)'))[1]
                 }
             }).then(function (response) {
                 that.elements = response;


### PR DESCRIPTION
- `docoment.cookie` can be an empty string and it gave me lot of trobles
- if `chartsData` has empty values the execution will break