### PR TITLE
Switched to GET call (task #10553)

### DIFF
--- a/webroot/js/reportGraphs.js
+++ b/webroot/js/reportGraphs.js
@@ -99,13 +99,12 @@
 
             $.ajax({
                 url: this.ajax.url,
-                method: 'POST',
+                method: 'GET',
                 headers: {
                     Accept: 'application/json',
                     'Content-Type': 'application/json',
                     Authorization: 'Bearer ' + this.ajax.token
                 },
-                data: JSON.stringify(this.ajax.data),
                 success: function (data, textStatus, jqXHR) {
                     // remove placeholder
                     $('#' + placeholder.id).remove();


### PR DESCRIPTION
POST requests to search functionality modify the saved search data, resetting the _latest_ saved data. This is expected on the search page since each POST request includes search data, but on graphs rendering no data are passed breaking the search query logic.