### PR TITLE
Bugfix for empty array as filter value (task #8668)

### DIFF
--- a/src/Filter/Equal.php
+++ b/src/Filter/Equal.php
@@ -29,7 +29,7 @@ final class Equal extends AbstractFilter
         return $query->where(
             (new QueryExpression())->{$method}(
                 $this->field,
-                $this->value,
+                empty($this->value) ? '' : $this->value,
                 $query->getTypeMap()->type($this->field)
             )
         );

--- a/src/Filter/Equal.php
+++ b/src/Filter/Equal.php
@@ -29,7 +29,7 @@ final class Equal extends AbstractFilter
         return $query->where(
             (new QueryExpression())->{$method}(
                 $this->field,
-                empty($this->value) ? '' : $this->value,
+                [] === $this->value ? '' : $this->value,
                 $query->getTypeMap()->type($this->field)
             )
         );

--- a/src/Filter/NotEqual.php
+++ b/src/Filter/NotEqual.php
@@ -29,7 +29,7 @@ final class NotEqual extends AbstractFilter
         return $query->where(['OR' => [
             (new QueryExpression())->{$method}(
                 $this->field,
-                empty($this->value) ? '' : $this->value,
+                [] === $this->value ? '' : $this->value,
                 $query->getTypeMap()->type($this->field)
             ),
             (new QueryExpression())->isNull($this->field)

--- a/src/Filter/NotEqual.php
+++ b/src/Filter/NotEqual.php
@@ -29,7 +29,7 @@ final class NotEqual extends AbstractFilter
         return $query->where(['OR' => [
             (new QueryExpression())->{$method}(
                 $this->field,
-                $this->value,
+                empty($this->value) ? '' : $this->value,
                 $query->getTypeMap()->type($this->field)
             ),
             (new QueryExpression())->isNull($this->field)

--- a/tests/TestCase/Filter/EqualTest.php
+++ b/tests/TestCase/Filter/EqualTest.php
@@ -74,4 +74,26 @@ class EqualTest extends TestCase
             Hash::extract($result->getValueBinder()->bindings(), '{s}.type')
         );
     }
+
+    public function testApplyWithEmptyArray() : void
+    {
+        $filter = new Equal('title', []);
+
+        $result = $filter->apply($this->query);
+
+        $this->assertRegExp(
+            '/WHERE "title" IN \(:c0\)/',
+            $result->sql()
+        );
+
+        $this->assertEquals(
+            [''],
+            Hash::extract($result->getValueBinder()->bindings(), '{s}.value')
+        );
+
+        $this->assertEquals(
+            ['string'],
+            Hash::extract($result->getValueBinder()->bindings(), '{s}.type')
+        );
+    }
 }

--- a/tests/TestCase/Filter/NotEqualTest.php
+++ b/tests/TestCase/Filter/NotEqualTest.php
@@ -74,4 +74,26 @@ class NotEqualTest extends TestCase
             Hash::extract($result->getValueBinder()->bindings(), '{s}.type')
         );
     }
+
+    public function testApplyWithEmtpyArray() : void
+    {
+        $filter = new NotEqual('title', []);
+
+        $result = $filter->apply($this->query);
+
+        $this->assertRegExp(
+            '/WHERE \("title" NOT IN \(:c0\) OR \("title"\) IS NULL\)/',
+            $result->sql()
+        );
+
+        $this->assertEquals(
+            [''],
+            Hash::extract($result->getValueBinder()->bindings(), '{s}.value')
+        );
+
+        $this->assertEquals(
+            ['string'],
+            Hash::extract($result->getValueBinder()->bindings(), '{s}.type')
+        );
+    }
 }


### PR DESCRIPTION
This PR addresses the issue of broken search query when an empty array is provided as value.