### PR TITLE
Add custom finder (task #10667)

### DIFF
--- a/src/Widgets/ReportWidget.php
+++ b/src/Widgets/ReportWidget.php
@@ -250,11 +250,21 @@ class ReportWidget extends BaseWidget
             return [];
         }
 
-        $resultSet = ConnectionManager::get('default')
-            ->execute($config['info']['query'])
-            ->fetchAll('assoc');
-        if (empty($resultSet)) {
-            return [];
+        $resultSet = [];
+
+        if (!empty($config['info']['finders'])) {
+            $table = $config['info']['model'];
+
+            $finder = $config['info']['finders']['name'];
+            $options = !empty($config['info']['finders']['options']) ? $config['info']['finders']['options'] : [];
+
+            $resultSet = TableRegistry::get($table)->find($finder, $options);
+        }
+
+        if (empty($config['info']['finders']) && !empty($config['info']['query'])) {
+            $resultSet = ConnectionManager::get('default')
+                ->execute($config['info']['query'])
+                ->fetchAll('assoc');
         }
 
         $columns = explode(',', $config['info']['columns']);

--- a/src/Widgets/ReportWidget.php
+++ b/src/Widgets/ReportWidget.php
@@ -257,7 +257,7 @@ class ReportWidget extends BaseWidget
             $table = $config['info']['model'];
 
             $finder = $config['info']['finders']['name'];
-            $options = Hash::get($config['info']['finders'], 'options', []);
+            $options = Hash::get($config, 'info.finders.options', []);
 
             $resultSet = TableRegistry::get($table)->find($finder, $options);
         }

--- a/src/Widgets/ReportWidget.php
+++ b/src/Widgets/ReportWidget.php
@@ -14,6 +14,7 @@ namespace Search\Widgets;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
+use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use RuntimeException;
 use Search\Event\EventName;
@@ -256,7 +257,7 @@ class ReportWidget extends BaseWidget
             $table = $config['info']['model'];
 
             $finder = $config['info']['finders']['name'];
-            $options = !empty($config['info']['finders']['options']) ? $config['info']['finders']['options'] : [];
+            $options = Hash::get($config['info']['finders'], 'options', []);
 
             $resultSet = TableRegistry::get($table)->find($finder, $options);
         }

--- a/src/Widgets/ReportWidget.php
+++ b/src/Widgets/ReportWidget.php
@@ -253,16 +253,16 @@ class ReportWidget extends BaseWidget
 
         $resultSet = [];
 
-        if (!empty($config['info']['finders'])) {
+        if (!empty($config['info']['finder'])) {
             $table = $config['info']['model'];
 
-            $finder = $config['info']['finders']['name'];
-            $options = Hash::get($config, 'info.finders.options', []);
+            $finder = $config['info']['finder']['name'];
+            $options = Hash::get($config, 'info.finder.options', []);
 
             $resultSet = TableRegistry::get($table)->find($finder, $options);
         }
 
-        if (empty($config['info']['finders']) && !empty($config['info']['query'])) {
+        if (empty($config['info']['finder']) && !empty($config['info']['query'])) {
             $resultSet = ConnectionManager::get('default')
                 ->execute($config['info']['query'])
                 ->fetchAll('assoc');

--- a/src/Widgets/ReportWidget.php
+++ b/src/Widgets/ReportWidget.php
@@ -14,6 +14,7 @@ namespace Search\Widgets;
 use Cake\Datasource\ConnectionManager;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
+use Cake\ORM\TableRegistry;
 use Cake\Utility\Hash;
 use Cake\Utility\Inflector;
 use RuntimeException;

--- a/tests/App/Model/Table/ArticlesTable.php
+++ b/tests/App/Model/Table/ArticlesTable.php
@@ -1,6 +1,7 @@
 <?php
 namespace Search\Test\App\Model\Table;
 
+use Cake\ORM\Query;
 use Cake\ORM\Table;
 
 class ArticlesTable extends Table
@@ -18,7 +19,13 @@ class ArticlesTable extends Table
         $this->belongsTo('Authors');
     }
 
-    public function findTitle($query, array $options)
+    /**
+     * Custom finder
+     * @param  Query  $query   defult query
+     * @param  mixed[]  $options where option
+     * @return mixed[]
+     */
+    public function findTitle(Query $query, array $options) : array
     {
         $query = $this->find()->enableHydration(false);
         $results = $query

--- a/tests/App/Model/Table/ArticlesTable.php
+++ b/tests/App/Model/Table/ArticlesTable.php
@@ -17,4 +17,18 @@ class ArticlesTable extends Table
 
         $this->belongsTo('Authors');
     }
+
+    public function findTitle($query, array $options)
+    {
+        $query = $this->find()->enableHydration(false);
+        $results = $query
+                    ->select(['title',
+                              'content'
+                             ], true)
+                    ->where($options)
+                    ->all()
+                    ->toArray();
+
+        return $results;
+    }
 }

--- a/tests/TestCase/Widgets/ReportWidgetTest.php
+++ b/tests/TestCase/Widgets/ReportWidgetTest.php
@@ -18,6 +18,7 @@ class ReportWidgetTest extends TestCase
     protected $widget;
 
     public $Widgets;
+    public $Articles;
 
     public $fixtureManager;
     public $appView;
@@ -27,6 +28,7 @@ class ReportWidgetTest extends TestCase
 
     public $fixtures = [
         'plugin.search.widgets',
+        'plugin.search.articles'
     ];
 
     public function setUp()
@@ -47,6 +49,9 @@ class ReportWidgetTest extends TestCase
 
         $config = TableRegistry::exists('Widgets') ? [] : ['className' => 'Search\Model\Table\WidgetsTable'];
         $this->Widgets = TableRegistry::get('Widgets', $config);
+
+        // $config = TableRegistry::exists('Articles') ? [] : ['className' => 'Search\Test\App\Model\Table\ArticlesTable'];
+        $this->Articles = TableRegistry::get('Articles');
 
         $this->fixtureManager->load($this);
     }
@@ -321,6 +326,39 @@ class ReportWidgetTest extends TestCase
     {
         $result = $this->widget->getQueryData([]);
         $this->assertEquals($result, []);
+    }
+
+    public function testGetQueryDataFinder(): void
+    {
+        $config = [
+            'modelName' => 'Articles',
+            'slug' => 'Articles',
+            'info' => [
+                'id' => '00000000-0000-0000-0001-000000000001',
+                'model' => 'Articles',
+                'widget_type' => 'report',
+                'name' => 'Articles',
+                'columns' => 'title,content',
+                'renderAs' => 'barChart',
+                'finder' => [
+                    'name' => 'title',
+                    'options' => [
+                        'title' => 'First article title'
+                    ]
+                ],
+                'y_axis' => 'total_amount',
+                'x_axis' => 'quarter'
+            ]
+        ];
+
+        $query = $this->widget->getQueryData($config);
+        $results = [
+                        0 => [
+                            'title' => 'First article title',
+                            'content' => 'First article content.'
+                        ]
+                    ];
+        $this->assertEquals($results, $query);
     }
 
     /**


### PR DESCRIPTION
The hard coded SQL queries can be replaced now with custom finder methods: in the `reports.json` we can add 
```      
"finders" : {
	"name" : "<finder_name>",
	"options" : {
  		"<where_option>" : "<where_option>"
	}
}
```
The finder method will be in the proper table class as `findFinderName` and have to return an array.
Simple `where` condition (anonymous function are not supported) can be add directly in the options.