### PR TITLE
Added search support for M:M and 1:M associations (task #12481)

### DIFF
--- a/src/Service/Search.php
+++ b/src/Service/Search.php
@@ -202,12 +202,12 @@ final class Search
         foreach ($this->getAssociations() as $association) {
             switch ($association->type()) {
                 case Association::MANY_TO_ONE:
+                case Association::MANY_TO_MANY:
+                case Association::ONE_TO_MANY:
                     $this->query->leftJoinWith($association->getName());
                     break;
 
                 case Association::ONE_TO_ONE:
-                case Association::ONE_TO_MANY:
-                case Association::MANY_TO_MANY:
                 default:
                     break;
             }

--- a/tests/App/Model/Table/ArticlesTable.php
+++ b/tests/App/Model/Table/ArticlesTable.php
@@ -17,6 +17,7 @@ class ArticlesTable extends Table
         $this->addBehavior('Timestamp');
 
         $this->belongsTo('Authors');
+        $this->belongsToMany('Tags');
     }
 
     /**

--- a/tests/App/Model/Table/TagsTable.php
+++ b/tests/App/Model/Table/TagsTable.php
@@ -1,0 +1,19 @@
+<?php
+namespace Search\Test\App\Model\Table;
+
+use Cake\ORM\Query;
+use Cake\ORM\Table;
+
+class TagsTable extends Table
+{
+    public function initialize(array $config)
+    {
+        parent::initialize($config);
+
+        $this->setTable('tags');
+        $this->setPrimaryKey('id');
+        $this->setDisplayField('name');
+
+        $this->belongsToMany('Articles');
+    }
+}

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -58,5 +58,14 @@ class ArticlesFixture extends TestFixture
             'modified' => '2016-04-27 08:21:54',
             'published' => 0,
         ],
+        [
+            'id' => '00000000-0000-0000-0000-000000000003',
+            'author_id' => '00000000-0000-0000-0000-000000000002',
+            'title' => 'Third article title',
+            'content' => 'Third article title',
+            'created' => '2019-07-25 16:00:13',
+            'modified' => '2019-07-25 16:00:13',
+            'published' => 1,
+        ]
     ];
 }

--- a/tests/Fixture/ArticlesTagsFixture.php
+++ b/tests/Fixture/ArticlesTagsFixture.php
@@ -1,0 +1,51 @@
+<?php
+namespace Search\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class ArticlesTagsFixture extends TestFixture
+{
+
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // @codingStandardsIgnoreStart
+    public $fields = [
+        'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'article_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'tag_id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'id' => '00000000-0000-0000-0000-000000000001',
+            'article_id' => '00000000-0000-0000-0000-000000000001',
+            'tag_id' => '00000000-0000-0000-0000-000000000001',
+        ],
+        [
+            'id' => '00000000-0000-0000-0000-000000000002',
+            'article_id' => '00000000-0000-0000-0000-000000000001',
+            'tag_id' => '00000000-0000-0000-0000-000000000002',
+        ],
+        [
+            'id' => '00000000-0000-0000-0000-000000000003',
+            'article_id' => '00000000-0000-0000-0000-000000000002',
+            'tag_id' => '00000000-0000-0000-0000-000000000002',
+        ],
+    ];
+}

--- a/tests/Fixture/TagsFixture.php
+++ b/tests/Fixture/TagsFixture.php
@@ -1,0 +1,47 @@
+<?php
+namespace Search\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class TagsFixture extends TestFixture
+{
+
+    /**
+     * Fields
+     *
+     * @var array
+     */
+    // @codingStandardsIgnoreStart
+    public $fields = [
+        'id' => ['type' => 'uuid', 'length' => null, 'null' => false, 'default' => null, 'comment' => '', 'precision' => null],
+        'name' => ['type' => 'string', 'length' => 255, 'null' => true, 'default' => null, 'comment' => '', 'precision' => null, 'fixed' => null],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id'], 'length' => []],
+        ],
+        '_options' => [
+            'engine' => 'InnoDB',
+            'collation' => 'utf8_general_ci'
+        ],
+    ];
+    // @codingStandardsIgnoreEnd
+
+    /**
+     * Records
+     *
+     * @var array
+     */
+    public $records = [
+        [
+            'id' => '00000000-0000-0000-0000-000000000001',
+            'name' => '#first_tag',
+        ],
+        [
+            'id' => '00000000-0000-0000-0000-000000000002',
+            'name' => '#another_tag',
+        ],
+        [
+            'id' => '00000000-0000-0000-0000-000000000003',
+            'name' => '#third_one',
+        ]
+    ];
+}

--- a/tests/TestCase/Controller/ArticlesControllerTest.php
+++ b/tests/TestCase/Controller/ArticlesControllerTest.php
@@ -101,7 +101,7 @@ class ArticlesControllerTest extends JsonIntegrationTestCase
         $this->assertResponseContains('First article title');
 
         $response = $this->getParsedResponse();
-        $this->assertEquals(2, $response->pagination->count);
+        $this->assertEquals(3, $response->pagination->count);
     }
 
     public function testSearchAjaxWithPrimaryKey(): void
@@ -121,7 +121,7 @@ class ArticlesControllerTest extends JsonIntegrationTestCase
         $this->assertJsonResponseOk();
 
         $response = $this->getParsedResponse();
-        $this->assertEquals('00000000-0000-0000-0000-000000000002', $response->data[0]->{'Articles.id'});
+        $this->assertEquals('00000000-0000-0000-0000-000000000003', $response->data[0]->{'Articles.id'});
     }
 
     public function testSearchAjaxWithGroupBy(): void
@@ -298,7 +298,7 @@ class ArticlesControllerTest extends JsonIntegrationTestCase
         $this->assertResponseOk();
 
         $this->assertEquals('lorem-ipsum', $this->viewVariable('filename'));
-        $this->assertEquals(2, $this->viewVariable('count'));
+        $this->assertEquals(3, $this->viewVariable('count'));
     }
 
     public function testExportSearchAjax(): void

--- a/tests/TestCase/Service/SearchTest.php
+++ b/tests/TestCase/Service/SearchTest.php
@@ -192,7 +192,7 @@ class SearchTest extends TestCase
         $this->table->deleteAll([]);
         $this->table->saveMany(
             $this->table->newEntities([
-                ['title' => 'one', 'content' => 'bla bla', 'tags' => ['_ids' => ['00000000-0000-0000-0000-000000000001']]],
+                ['title' => 'one', 'content' => 'bla bla', 'tags' => ['_ids' => ['00000000-0000-0000-0000-000000000001', '00000000-0000-0000-0000-000000000002']]],
                 ['title' => 'two', 'content' => 'bla bla', 'tags' => ['_ids' => ['00000000-0000-0000-0000-000000000002']]],
                 ['title' => 'three', 'content' => 'bla bla', 'tags' => ['_ids' => ['00000000-0000-0000-0000-000000000001']]],
                 ['title' => 'four', 'content' => 'bla bla', 'tags' => ['_ids' => ['00000000-0000-0000-0000-000000000003']]],
@@ -209,10 +209,11 @@ class SearchTest extends TestCase
         $query->order(['Articles.title' => 'ASC']);
         $entities = $query->toArray();
 
-        $this->assertCount(3, $entities);
+        $this->assertCount(4, $entities);
         $this->assertSame(['one', '#first_tag'], [$entities[0]->get('title'), $entities[0]->get('_matchingData')['Tags']->get('name')]);
-        $this->assertSame(['three', '#first_tag'], [$entities[1]->get('title'), $entities[1]->get('_matchingData')['Tags']->get('name')]);
-        $this->assertSame(['two', '#another_tag'], [$entities[2]->get('title'), $entities[2]->get('_matchingData')['Tags']->get('name')]);
+        $this->assertSame(['one', '#another_tag'], [$entities[1]->get('title'), $entities[1]->get('_matchingData')['Tags']->get('name')]);
+        $this->assertSame(['three', '#first_tag'], [$entities[2]->get('title'), $entities[2]->get('_matchingData')['Tags']->get('name')]);
+        $this->assertSame(['two', '#another_tag'], [$entities[3]->get('title'), $entities[3]->get('_matchingData')['Tags']->get('name')]);
     }
 
     public function testExecuteWithAssociatedOneToMany() : void
@@ -243,6 +244,7 @@ class SearchTest extends TestCase
         Assert::isInstanceOf($entity, \Cake\Datasource\EntityInterface::class);
 
         $this->assertSame('Author 1', $entity->get('name'));
+        $this->assertSame('First article title', $entity->get('_matchingData')['Articles']->get('title'));
     }
 
     public function testExecuteWithAssociatedInvalid() : void

--- a/tests/TestCase/Service/SearchTest.php
+++ b/tests/TestCase/Service/SearchTest.php
@@ -14,6 +14,7 @@ namespace Search\Test\TestCase\Service;
 use Cake\Datasource\EntityInterface;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
+use Search\Filter\EndsWith;
 use Search\Filter\Equal;
 use Search\Filter\StartsWith;
 use Search\Service\Criteria;
@@ -24,7 +25,9 @@ class SearchTest extends TestCase
 {
     public $fixtures = [
         'plugin.Search.articles',
-        'plugin.Search.authors'
+        'plugin.Search.articles_tags',
+        'plugin.Search.authors',
+        'plugin.Search.tags'
     ];
 
     private $table;
@@ -131,7 +134,40 @@ class SearchTest extends TestCase
         $this->assertEquals(2, $result->get('total'));
     }
 
-    public function testExecuteWithAssociated() : void
+    public function testExecuteWithGroupByAssociated() : void
+    {
+        $this->table->deleteAll([]);
+        $this->table->saveMany(
+            $this->table->newEntities([
+                ['title' => 'one', 'content' => 'bla bla', 'author_id' => '00000000-0000-0000-0000-000000000001'],
+                ['title' => 'two', 'content' => 'bla bla', 'author_id' => '00000000-0000-0000-0000-000000000001'],
+                ['title' => 'three', 'content' => 'bla bla', 'author_id' => '00000000-0000-0000-0000-000000000001'],
+                ['title' => 'four', 'content' => 'bla bla', 'author_id' => '00000000-0000-0000-0000-000000000002'],
+            ])
+        );
+
+        $query = $this->table->find();
+        $query->group('Authors.name');
+
+        $search = new Search($query, $this->table);
+
+        $query = $search->execute();
+        $query->order(['total' => 'DESC']);
+        $entities = $query->toArray();
+
+        $this->assertCount(2, $entities);
+
+        $this->assertSame(
+            [3, 'Stephen King'],
+            [$entities[0]->get('total'), $entities[0]->get('_matchingData')['Authors']->get('name')]
+        );
+        $this->assertSame(
+            [1, 'Mark Twain'],
+            [$entities[1]->get('total'), $entities[1]->get('_matchingData')['Authors']->get('name')]
+        );
+    }
+
+    public function testExecuteWithAssociatedManyToOne() : void
     {
         $this->table->deleteAll([]);
         $this->table->save(
@@ -142,12 +178,71 @@ class SearchTest extends TestCase
             ])
         );
 
-        $search = new Search($this->table->find(), $this->table);
+        $query = $this->table->find();
+        $search = new Search($query, $this->table);
         $search->addCriteria(new Criteria(['field' => 'Authors.name', 'operator' => Equal::class, 'value' => 'Stephen King']));
 
         $query = $search->execute();
 
         $this->assertCount(1, $query);
+    }
+
+    public function testExecuteWithAssociatedManyToMany() : void
+    {
+        $this->table->deleteAll([]);
+        $this->table->saveMany(
+            $this->table->newEntities([
+                ['title' => 'one', 'content' => 'bla bla', 'tags' => ['_ids' => ['00000000-0000-0000-0000-000000000001']]],
+                ['title' => 'two', 'content' => 'bla bla', 'tags' => ['_ids' => ['00000000-0000-0000-0000-000000000002']]],
+                ['title' => 'three', 'content' => 'bla bla', 'tags' => ['_ids' => ['00000000-0000-0000-0000-000000000001']]],
+                ['title' => 'four', 'content' => 'bla bla', 'tags' => ['_ids' => ['00000000-0000-0000-0000-000000000003']]],
+                ['title' => 'five', 'content' => 'bla bla', 'tags' => ['_ids' => ['00000000-0000-0000-0000-000000000003']]]
+            ])
+        );
+
+        $query = $this->table->find();
+        $query->select(['Articles.title', 'Tags.name']);
+        $search = new Search($query, $this->table);
+        $search->addCriteria(new Criteria(['field' => 'Tags.name', 'operator' => EndsWith::class, 'value' => '_tag']));
+
+        $query = $search->execute();
+        $query->order(['Articles.title' => 'ASC']);
+        $entities = $query->toArray();
+
+        $this->assertCount(3, $entities);
+        $this->assertSame(['one', '#first_tag'], [$entities[0]->get('title'), $entities[0]->get('_matchingData')['Tags']->get('name')]);
+        $this->assertSame(['three', '#first_tag'], [$entities[1]->get('title'), $entities[1]->get('_matchingData')['Tags']->get('name')]);
+        $this->assertSame(['two', '#another_tag'], [$entities[2]->get('title'), $entities[2]->get('_matchingData')['Tags']->get('name')]);
+    }
+
+    public function testExecuteWithAssociatedOneToMany() : void
+    {
+        $table = TableRegistry::getTableLocator()->get('Authors');
+
+        $table->deleteAll([]);
+        /**
+         * @var \Cake\Datasource\EntityInterface[]|\Cake\ORM\ResultSet
+         */
+        $newEntities = $table->newEntities([
+            ['name' => 'Author 1', 'articles' => ['_ids' => ['00000000-0000-0000-0000-000000000001']]],
+            ['name' => 'Author 2', 'articles' => ['_ids' => ['00000000-0000-0000-0000-000000000002']]]
+        ]);
+
+        $table->saveMany($newEntities);
+
+        $query = $table->find();
+        $query->select(['Authors.name', 'Articles.title']);
+        $search = new Search($query, $table);
+        $search->addCriteria(new Criteria(['field' => 'Articles.title', 'operator' => StartsWith::class, 'value' => 'First']));
+
+        $query = $search->execute();
+
+        $this->assertCount(1, $query);
+
+        $entity = $query->firstOrFail();
+        Assert::isInstanceOf($entity, \Cake\Datasource\EntityInterface::class);
+
+        $this->assertSame('Author 1', $entity->get('name'));
     }
 
     public function testExecuteWithAssociatedInvalid() : void

--- a/tests/TestCase/Service/SearchTest.php
+++ b/tests/TestCase/Service/SearchTest.php
@@ -170,11 +170,11 @@ class SearchTest extends TestCase
     public function testExecuteWithAssociatedManyToOne() : void
     {
         $this->table->deleteAll([]);
-        $this->table->save(
-            $this->table->newEntity([
-                'title' => 'one',
-                'content' => 'bla bla',
-                'author_id' => '00000000-0000-0000-0000-000000000001'
+        $this->table->saveMany(
+            $this->table->newEntities([
+                ['title' => 'one', 'content' => 'bla bla', 'author_id' => '00000000-0000-0000-0000-000000000001'],
+                ['title' => 'two', 'content' => 'bla bla', 'author_id' => '00000000-0000-0000-0000-000000000002'],
+                ['title' => 'three', 'content' => 'bla bla', 'author_id' => '00000000-0000-0000-0000-000000000001']
             ])
         );
 
@@ -183,8 +183,13 @@ class SearchTest extends TestCase
         $search->addCriteria(new Criteria(['field' => 'Authors.name', 'operator' => Equal::class, 'value' => 'Stephen King']));
 
         $query = $search->execute();
+        $query->order(['Articles.title' => 'ASC']);
+        $entities = $query->toArray();
 
-        $this->assertCount(1, $query);
+        $this->assertCount(2, $entities);
+
+        $this->assertSame('one', $entities[0]->get('title'));
+        $this->assertSame('three', $entities[1]->get('title'));
     }
 
     public function testExecuteWithAssociatedManyToMany() : void

--- a/tests/TestCase/Utility/ExportTest.php
+++ b/tests/TestCase/Utility/ExportTest.php
@@ -88,7 +88,7 @@ class ExportTest extends TestCase
 
     public function testCount(): void
     {
-        $this->assertEquals(2, $this->Export->count());
+        $this->assertEquals(3, $this->Export->count());
     }
 
     public function testGetUrl(): void
@@ -128,7 +128,7 @@ class ExportTest extends TestCase
         $this->assertEquals($count + 1, count($data));
 
         // test value with no html entities, no html tags, no spaces at begin and end string.
-        $content = $data[1][1];
+        $content = $data[2][1];
         $this->assertEquals('\'"Fovič"\' €€', $content);
     }
 }

--- a/tests/TestCase/Utility/SearchTest.php
+++ b/tests/TestCase/Utility/SearchTest.php
@@ -329,7 +329,7 @@ class SearchTest extends TestCase
         $entity = $result->firstOrFail();
 
         $this->assertInstanceOf(Query::class, $result);
-        $this->assertEquals(1, $result->count());
+        $this->assertEquals(2, $result->count());
 
         $this->assertNotEmpty($entity->get('id'));
         $this->assertNotEmpty($entity->get('title'));


### PR DESCRIPTION
This PR adds support for filtering search results through _M:M_ and _1:M_ associations.

**Note:** Adding columns from these associations to the `select` clause will not produce any errors, but is not recommended as it will not produce any meaningful results.