### PR TITLE
[WIP] Fix a bug that the App pane is visible only when initializing the page (Task #13269)

### DIFF
--- a/webroot/js/dashboard.js
+++ b/webroot/js/dashboard.js
@@ -37,6 +37,17 @@ var dashboard = dashboard || {};
 
             return true;
         });
+
+        $('#dashboardForm').on('click', '.widget-tab a', function(){
+            //Remove active class from all tab-pane
+            $('#dashboardForm .tab-content .tab-pane').each(function(){
+                $(this).removeClass('active');
+            });
+
+            var tabId = $(this).attr("href");
+            //Add active class to the selected tab-pane
+            $('#dashboardForm .tab-content ' + tabId).addClass('active');
+        })
     };
 
     /**


### PR DESCRIPTION
This PR fixes the issue that the App pane is visible only when initializing the page. It seems that we have a duplicate id="app" and the class "active" goes on the first element