### PR TITLE
Support for Cakephp v3.8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,12 +27,16 @@
 	"repositories": [
         {
             "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-file-storage.git"
+            "url": "https://github.com/QoboLtd/cakephp-utils.git"
+        },
+        {
+            "type": "git",
+            "url": "https://github.com/QoboLtd/cakephp-roles-capabilities.git"
         }
     ],
     "require": {
-        "qobo/cakephp-roles-capabilities": "^18.0",
-        "qobo/cakephp-utils": "^13.0"
+        "qobo/cakephp-roles-capabilities": "dev-cakephp-v38",
+        "qobo/cakephp-utils": "dev-cakephp-v38a"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"

--- a/composer.json
+++ b/composer.json
@@ -24,19 +24,9 @@
             "php": "7.1"
         }
     },
-	"repositories": [
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-utils.git"
-        },
-        {
-            "type": "git",
-            "url": "https://github.com/QoboLtd/cakephp-roles-capabilities.git"
-        }
-    ],
     "require": {
-        "qobo/cakephp-roles-capabilities": "dev-cakephp-v38",
-        "qobo/cakephp-utils": "dev-cakephp-v38a"
+        "qobo/cakephp-roles-capabilities": "^18.0",
+        "qobo/cakephp-utils": "^13.0"
     },
     "require-dev": {
         "qobo/cakephp-composer-dev": "^v1.0"
@@ -70,6 +60,5 @@
         "test": "Runs phpcs and phpunit without coverage",
         "test-coverage": "Runs phpcs and phpunit with coverage enabled"
     },
-    "prefer-stable": true,
-    "minimum-stability": "dev"
+    "prefer-stable": true
 }

--- a/src/Controller/DashboardsController.php
+++ b/src/Controller/DashboardsController.php
@@ -59,7 +59,7 @@ class DashboardsController extends AppController
         /**
          * @var \Search\Model\Table\WidgetsTable $widgetsTable
          */
-        $widgetsTable = TableRegistry::get('Search.Widgets');
+        $widgetsTable = TableRegistry::getTableLocator()->get('Search.Widgets');
 
         $userDashboards = $query->find('list')->toArray();
         if (!array_key_exists($dashboard->id, $userDashboards)) {
@@ -124,7 +124,7 @@ class DashboardsController extends AppController
         /**
          * @var \Search\Model\Table\WidgetsTable $widgetsTable
          */
-        $widgetsTable = TableRegistry::get('Search.Widgets');
+        $widgetsTable = TableRegistry::getTableLocator()->get('Search.Widgets');
         $widgets = $widgetsTable->getWidgets();
 
         if ($this->request->is('post')) {
@@ -183,7 +183,7 @@ class DashboardsController extends AppController
         /**
          * @var \Search\Model\Table\WidgetsTable $widgetsTable
          */
-        $widgetsTable = TableRegistry::get('Search.Widgets');
+        $widgetsTable = TableRegistry::getTableLocator()->get('Search.Widgets');
         $widgets = $widgetsTable->getWidgets();
 
         $sequence = 0;
@@ -228,7 +228,7 @@ class DashboardsController extends AppController
             if ($this->Dashboards->save($dashboard)) {
                 $this->Flash->success((string)__d('Qobo/Search', 'The dashboard has been saved.'));
                 /** @var \Search\Model\Table\WidgetsTable */
-                $widgetTable = TableRegistry::get('Search.Widgets');
+                $widgetTable = TableRegistry::getTableLocator()->get('Search.Widgets');
                 $widgetTable->trashAll([
                     'dashboard_id' => $dashboard->id,
                 ]);
@@ -264,7 +264,7 @@ class DashboardsController extends AppController
 
         if ($this->Dashboards->delete($dashboard)) {
             /** @var \Search\Model\Table\WidgetsTable */
-            $widgetTable = TableRegistry::get('Search.Widgets');
+            $widgetTable = TableRegistry::getTableLocator()->get('Search.Widgets');
             $widgetTable->trashAll([
                 'dashboard_id' => $id,
             ]);

--- a/src/Controller/WidgetsController.php
+++ b/src/Controller/WidgetsController.php
@@ -30,7 +30,7 @@ class WidgetsController extends AppController
         /**
          * @var \Search\Model\Table\WidgetsTable $table
          */
-        $table = TableRegistry::get('Search.Widgets');
+        $table = TableRegistry::getTableLocator()->get('Search.Widgets');
 
         $widgets = $table->getWidgets();
 

--- a/src/Event/Model/WidgetsListener.php
+++ b/src/Event/Model/WidgetsListener.php
@@ -57,7 +57,7 @@ class WidgetsListener implements EventListenerInterface
      */
     private function getSavedSearchWidgets(): array
     {
-        $table = TableRegistry::get('Search.SavedSearches');
+        $table = TableRegistry::getTableLocator()->get('Search.SavedSearches');
 
         $query = $table->find('all')
             ->where([
@@ -114,7 +114,7 @@ class WidgetsListener implements EventListenerInterface
      */
     private function getAppWidgets(): array
     {
-        $table = TableRegistry::get('Search.AppWidgets');
+        $table = TableRegistry::getTableLocator()->get('Search.AppWidgets');
 
         $query = $table->find('all')
             ->select(['id', 'name', 'content']);

--- a/src/Utility/Export.php
+++ b/src/Utility/Export.php
@@ -151,7 +151,7 @@ final class Export
             return [];
         }
 
-        $table = TableRegistry::get($this->search->get('model'));
+        $table = TableRegistry::getTableLocator()->get($this->search->get('model'));
 
         $associationLabels = self::getAssociationLabels($table);
         $fieldLabels = self::getFieldLabels($table, true);
@@ -198,7 +198,7 @@ final class Export
         return self::toCsv(
             $query->all(),
             array_map('strval', $this->data['fields']),
-            TableRegistry::get($this->search->get('model'))
+            TableRegistry::getTableLocator()->get($this->search->get('model'))
         );
     }
 

--- a/src/Widgets/AppWidget.php
+++ b/src/Widgets/AppWidget.php
@@ -77,7 +77,7 @@ class AppWidget extends BaseWidget
      */
     public function getResults(array $options = [])
     {
-        $table = TableRegistry::get('Search.AppWidgets');
+        $table = TableRegistry::getTableLocator()->get('Search.AppWidgets');
 
         /**
          * @var \Cake\Datasource\EntityInterface|null

--- a/src/Widgets/ReportWidget.php
+++ b/src/Widgets/ReportWidget.php
@@ -259,7 +259,7 @@ class ReportWidget extends BaseWidget
             $finder = $config['info']['finder']['name'];
             $options = Hash::get($config, 'info.finder.options', []);
 
-            $resultSet = TableRegistry::get($table)->find($finder, $options);
+            $resultSet = TableRegistry::getTableLocator()->get($table)->find($finder, $options);
         }
 
         if (empty($config['info']['finder']) && !empty($config['info']['query'])) {

--- a/src/Widgets/SavedSearchWidget.php
+++ b/src/Widgets/SavedSearchWidget.php
@@ -85,7 +85,7 @@ final class SavedSearchWidget extends BaseWidget
     {
         $this->setContainerId($options['entity']);
 
-        $table = TableRegistry::get('Search.SavedSearches');
+        $table = TableRegistry::getTableLocator()->get('Search.SavedSearches');
 
         /** @var \Search\Model\Entity\SavedSearch|null */
         $savedSearch = $table->find()

--- a/tests/TestCase/Aggregate/AverageTest.php
+++ b/tests/TestCase/Aggregate/AverageTest.php
@@ -18,7 +18,7 @@ use Search\Criteria\Field;
 
 class AverageTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Aggregate/CountTest.php
+++ b/tests/TestCase/Aggregate/CountTest.php
@@ -18,7 +18,7 @@ use Search\Criteria\Field;
 
 class CountTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Aggregate/MaximumTest.php
+++ b/tests/TestCase/Aggregate/MaximumTest.php
@@ -18,7 +18,7 @@ use Search\Criteria\Field;
 
 class MaximumTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Aggregate/MinimumTest.php
+++ b/tests/TestCase/Aggregate/MinimumTest.php
@@ -18,7 +18,7 @@ use Search\Criteria\Field;
 
 class MinimumTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Aggregate/SumTest.php
+++ b/tests/TestCase/Aggregate/SumTest.php
@@ -18,7 +18,7 @@ use Search\Criteria\Field;
 
 class SumTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Controller/DashboardsControllerTest.php
+++ b/tests/TestCase/Controller/DashboardsControllerTest.php
@@ -20,16 +20,16 @@ class DashboardsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.groups.groups',
-        'plugin.groups.groups_users',
-        'plugin.search.app_widgets',
-        'plugin.search.articles',
-        'plugin.search.dashboards',
-        'plugin.search.saved_searches',
-        'plugin.search.widgets',
-        'plugin.roles_capabilities.groups_roles',
-        'plugin.roles_capabilities.roles',
+        'plugin.CakeDC/Users.Users',
+        'plugin.Groups.Groups',
+        'plugin.Groups.GroupsUsers',
+        'plugin.Search.AppWidgets',
+        'plugin.Search.Articles',
+        'plugin.Search.Dashboards',
+        'plugin.Search.SavedSearches',
+        'plugin.Search.Widgets',
+        'plugin.RolesCapabilities.GroupsRoles',
+        'plugin.RolesCapabilities.Roles',
     ];
 
     public function setUp()

--- a/tests/TestCase/Controller/SavedSearchesControllerTest.php
+++ b/tests/TestCase/Controller/SavedSearchesControllerTest.php
@@ -15,8 +15,8 @@ class SavedSearchesControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.search.saved_searches',
+        'plugin.CakeDC/Users.Users',
+        'plugin.Search.SavedSearches',
     ];
 
     public function setUp()

--- a/tests/TestCase/Controller/WidgetsControllerTest.php
+++ b/tests/TestCase/Controller/WidgetsControllerTest.php
@@ -14,9 +14,9 @@ class WidgetsControllerTest extends IntegrationTestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.search.widgets',
-        'plugin.search.app_widgets',
-        'plugin.search.saved_searches',
+        'plugin.Search.Widgets',
+        'plugin.Search.AppWidgets',
+        'plugin.Search.SavedSearches',
     ];
 
     public function setUp()

--- a/tests/TestCase/Filter/ContainsTest.php
+++ b/tests/TestCase/Filter/ContainsTest.php
@@ -28,7 +28,7 @@ class ContainsTest extends TestCase
     {
         parent::setUp();
 
-        $this->query = TableRegistry::get('Articles')->query();
+        $this->query = TableRegistry::getTableLocator()->get('Articles')->query();
     }
 
     public function tearDown(): void

--- a/tests/TestCase/Filter/ContainsTest.php
+++ b/tests/TestCase/Filter/ContainsTest.php
@@ -20,7 +20,7 @@ use Search\Filter\Contains;
 
 class ContainsTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Filter/EndsWithTest.php
+++ b/tests/TestCase/Filter/EndsWithTest.php
@@ -21,7 +21,7 @@ use Search\Filter\EndsWith;
 
 class EndsWithTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Filter/EndsWithTest.php
+++ b/tests/TestCase/Filter/EndsWithTest.php
@@ -29,7 +29,7 @@ class EndsWithTest extends TestCase
     {
         parent::setUp();
 
-        $this->query = TableRegistry::get('Articles')->query();
+        $this->query = TableRegistry::getTableLocator()->get('Articles')->query();
     }
 
     public function tearDown(): void

--- a/tests/TestCase/Filter/EqualTest.php
+++ b/tests/TestCase/Filter/EqualTest.php
@@ -28,7 +28,7 @@ class EqualTest extends TestCase
     {
         parent::setUp();
 
-        $this->query = TableRegistry::get('Articles')->query();
+        $this->query = TableRegistry::getTableLocator()->get('Articles')->query();
     }
 
     public function tearDown(): void

--- a/tests/TestCase/Filter/EqualTest.php
+++ b/tests/TestCase/Filter/EqualTest.php
@@ -20,7 +20,7 @@ use Search\Filter\Equal;
 
 class EqualTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Filter/GreaterOrEqualTest.php
+++ b/tests/TestCase/Filter/GreaterOrEqualTest.php
@@ -20,7 +20,7 @@ use Search\Filter\GreaterOrEqual;
 
 class GreaterOrEqualTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Filter/GreaterOrEqualTest.php
+++ b/tests/TestCase/Filter/GreaterOrEqualTest.php
@@ -28,7 +28,7 @@ class GreaterOrEqualTest extends TestCase
     {
         parent::setUp();
 
-        $this->query = TableRegistry::get('Articles')->query();
+        $this->query = TableRegistry::getTableLocator()->get('Articles')->query();
     }
 
     public function tearDown(): void

--- a/tests/TestCase/Filter/GreaterTest.php
+++ b/tests/TestCase/Filter/GreaterTest.php
@@ -28,7 +28,7 @@ class GreaterTest extends TestCase
     {
         parent::setUp();
 
-        $this->query = TableRegistry::get('Articles')->query();
+        $this->query = TableRegistry::getTableLocator()->get('Articles')->query();
     }
 
     public function tearDown(): void

--- a/tests/TestCase/Filter/GreaterTest.php
+++ b/tests/TestCase/Filter/GreaterTest.php
@@ -20,7 +20,7 @@ use Search\Filter\Greater;
 
 class GreaterTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Filter/LessOrEqualTest.php
+++ b/tests/TestCase/Filter/LessOrEqualTest.php
@@ -28,7 +28,7 @@ class LessOrEqualTest extends TestCase
     {
         parent::setUp();
 
-        $this->query = TableRegistry::get('Articles')->query();
+        $this->query = TableRegistry::getTableLocator()->get('Articles')->query();
     }
 
     public function tearDown(): void

--- a/tests/TestCase/Filter/LessOrEqualTest.php
+++ b/tests/TestCase/Filter/LessOrEqualTest.php
@@ -20,7 +20,7 @@ use Search\Filter\LessOrEqual;
 
 class LessOrEqualTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Filter/LessTest.php
+++ b/tests/TestCase/Filter/LessTest.php
@@ -20,7 +20,7 @@ use Search\Filter\Less;
 
 class LessTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Filter/LessTest.php
+++ b/tests/TestCase/Filter/LessTest.php
@@ -28,7 +28,7 @@ class LessTest extends TestCase
     {
         parent::setUp();
 
-        $this->query = TableRegistry::get('Articles')->query();
+        $this->query = TableRegistry::getTableLocator()->get('Articles')->query();
     }
 
     public function tearDown(): void

--- a/tests/TestCase/Filter/NotContainsTest.php
+++ b/tests/TestCase/Filter/NotContainsTest.php
@@ -28,7 +28,7 @@ class NotContainsTest extends TestCase
     {
         parent::setUp();
 
-        $this->query = TableRegistry::get('Articles')->query();
+        $this->query = TableRegistry::getTableLocator()->get('Articles')->query();
     }
 
     public function tearDown(): void

--- a/tests/TestCase/Filter/NotContainsTest.php
+++ b/tests/TestCase/Filter/NotContainsTest.php
@@ -20,7 +20,7 @@ use Search\Filter\NotContains;
 
 class NotContainsTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Filter/NotEqualTest.php
+++ b/tests/TestCase/Filter/NotEqualTest.php
@@ -20,7 +20,7 @@ use Search\Filter\NotEqual;
 
 class NotEqualTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Filter/NotEqualTest.php
+++ b/tests/TestCase/Filter/NotEqualTest.php
@@ -28,7 +28,7 @@ class NotEqualTest extends TestCase
     {
         parent::setUp();
 
-        $this->query = TableRegistry::get('Articles')->query();
+        $this->query = TableRegistry::getTableLocator()->get('Articles')->query();
     }
 
     public function tearDown(): void

--- a/tests/TestCase/Filter/StartsWithTest.php
+++ b/tests/TestCase/Filter/StartsWithTest.php
@@ -20,7 +20,7 @@ use Search\Filter\StartsWith;
 
 class StartsWithTest extends TestCase
 {
-    public $fixtures = ['plugin.Search.articles'];
+    public $fixtures = ['plugin.Search.Articles'];
 
     private $query;
 

--- a/tests/TestCase/Filter/StartsWithTest.php
+++ b/tests/TestCase/Filter/StartsWithTest.php
@@ -28,7 +28,7 @@ class StartsWithTest extends TestCase
     {
         parent::setUp();
 
-        $this->query = TableRegistry::get('Articles')->query();
+        $this->query = TableRegistry::getTableLocator()->get('Articles')->query();
     }
 
     public function tearDown(): void

--- a/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/SearchableBehaviorTest.php
@@ -19,8 +19,8 @@ use Search\Filter\StartsWith;
 class SearchableBehaviorTest extends TestCase
 {
     public $fixtures = [
-        'plugin.Search.articles',
-        'plugin.Search.authors',
+        'plugin.Search.Articles',
+        'plugin.Search.Authors',
     ];
 
     private $articles;

--- a/tests/TestCase/Model/Table/AppWidgetsTableTest.php
+++ b/tests/TestCase/Model/Table/AppWidgetsTableTest.php
@@ -9,7 +9,7 @@ use Cake\TestSuite\TestCase;
  */
 class AppWidgetsTableTest extends TestCase
 {
-    public $fixtures = ['plugin.search.app_widgets'];
+    public $fixtures = ['plugin.Search.AppWidgets'];
 
     private $table;
 

--- a/tests/TestCase/Model/Table/DashboardsTableTest.php
+++ b/tests/TestCase/Model/Table/DashboardsTableTest.php
@@ -43,11 +43,11 @@ class DashboardsTableTest extends TestCase
     {
         parent::setUp();
 
-        $config = TableRegistry::exists('Search.Dashboards') ? [] : ['className' => 'Search\Model\Table\DashboardsTable'];
+        $config = TableRegistry::getTableLocator()->exists('Search.Dashboards') ? [] : ['className' => 'Search\Model\Table\DashboardsTable'];
         /**
          * @var \Search\Model\Table\DashboardsTable $table
          */
-        $table = TableRegistry::get('Search.Dashboards', $config);
+        $table = TableRegistry::getTableLocator()->get('Search.Dashboards', $config);
         $this->Dashboards = $table;
     }
 

--- a/tests/TestCase/Model/Table/DashboardsTableTest.php
+++ b/tests/TestCase/Model/Table/DashboardsTableTest.php
@@ -26,12 +26,12 @@ class DashboardsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.search.dashboards',
-        'plugin.CakeDC/Users.users',
-        'plugin.groups.groups',
-        'plugin.groups.groups_users',
-        'plugin.roles_capabilities.groups_roles',
-        'plugin.roles_capabilities.roles',
+        'plugin.Search.Dashboards',
+        'plugin.CakeDC/Users.Users',
+        'plugin.Groups.Groups',
+        'plugin.Groups.GroupsUsers',
+        'plugin.RolesCapabilities.GroupsRoles',
+        'plugin.RolesCapabilities.Roles',
     ];
 
     /**

--- a/tests/TestCase/Model/Table/SavedSearchesTableTest.php
+++ b/tests/TestCase/Model/Table/SavedSearchesTableTest.php
@@ -18,8 +18,8 @@ class SavedSearchesTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.search.saved_searches',
+        'plugin.CakeDC/Users.Users',
+        'plugin.Search.SavedSearches',
     ];
 
     private $SavedSearches;

--- a/tests/TestCase/Model/Table/WidgetsTableTest.php
+++ b/tests/TestCase/Model/Table/WidgetsTableTest.php
@@ -24,10 +24,10 @@ class WidgetsTableTest extends TestCase
      * @var array
      */
     public $fixtures = [
-        'plugin.search.widgets',
-        'plugin.search.app_widgets',
-        'plugin.search.dashboards',
-        'plugin.search.saved_searches',
+        'plugin.Search.Widgets',
+        'plugin.Search.AppWidgets',
+        'plugin.Search.Dashboards',
+        'plugin.Search.SavedSearches',
     ];
 
     /**

--- a/tests/TestCase/Service/SearchTest.php
+++ b/tests/TestCase/Service/SearchTest.php
@@ -26,10 +26,10 @@ use Webmozart\Assert\Assert;
 class SearchTest extends TestCase
 {
     public $fixtures = [
-        'plugin.Search.articles',
-        'plugin.Search.articles_tags',
-        'plugin.Search.authors',
-        'plugin.Search.tags',
+        'plugin.Search.Articles',
+        'plugin.Search.ArticlesTags',
+        'plugin.Search.Authors',
+        'plugin.Search.Tags',
     ];
 
     private $table;
@@ -104,7 +104,7 @@ class SearchTest extends TestCase
 
         $result = $query->firstOrFail();
         Assert::isInstanceOf($result, \Cake\Datasource\EntityInterface::class);
-        $this->assertEquals([], array_diff(['title', 'content'], $result->visibleProperties()));
+        $this->assertEquals([], array_diff(['title', 'content'], $result->getVisible()));
     }
 
     public function testShouldExecuteWithGroupBy(): void

--- a/tests/TestCase/Shell/SearchShellTest.php
+++ b/tests/TestCase/Shell/SearchShellTest.php
@@ -10,8 +10,8 @@ use Cake\TestSuite\ConsoleIntegrationTestCase;
 class SearchShellTest extends ConsoleIntegrationTestCase
 {
     public $fixtures = [
-        'plugin.CakeDC/Users.users',
-        'plugin.Search.saved_searches',
+        'plugin.CakeDC/Users.Users',
+        'plugin.Search.SavedSearches',
     ];
 
     private $table;

--- a/tests/TestCase/Transformer/QueryDataTransformerTest.php
+++ b/tests/TestCase/Transformer/QueryDataTransformerTest.php
@@ -22,7 +22,7 @@ use Search\Transformer\QueryDataTransformer;
 class QueryDataTransformerTest extends TestCase
 {
     public $fixtures = [
-        'plugin.Search.articles',
+        'plugin.Search.Articles',
     ];
 
     private $table;

--- a/tests/TestCase/Utility/ExportTest.php
+++ b/tests/TestCase/Utility/ExportTest.php
@@ -13,9 +13,9 @@ use Search\Utility\Export;
 class ExportTest extends TestCase
 {
     public $fixtures = [
-        'plugin.search.articles',
-        'plugin.search.authors',
-        'plugin.search.saved_searches',
+        'plugin.Search.Articles',
+        'plugin.Search.Authors',
+        'plugin.Search.SavedSearches',
     ];
 
     private $user;

--- a/tests/TestCase/Widgets/AppWidgetTest.php
+++ b/tests/TestCase/Widgets/AppWidgetTest.php
@@ -13,8 +13,8 @@ use Search\Widgets\AppWidget;
 class AppWidgetTest extends TestCase
 {
     public $fixtures = [
-        'plugin.search.app_widgets',
-        'plugin.search.widgets',
+        'plugin.Search.AppWidgets',
+        'plugin.Search.Widgets',
     ];
 
     public $widget;

--- a/tests/TestCase/Widgets/AppWidgetTest.php
+++ b/tests/TestCase/Widgets/AppWidgetTest.php
@@ -28,18 +28,18 @@ class AppWidgetTest extends TestCase
     {
         $this->widget = new AppWidget(['foo' => 'bar']);
 
-        $config = TableRegistry::exists('Search.AppWidgets') ? [] : ['className' => 'Search\Model\Table\AppWidgetsTable'];
+        $config = TableRegistry::getTableLocator()->exists('Search.AppWidgets') ? [] : ['className' => 'Search\Model\Table\AppWidgetsTable'];
         /**
          * @var \Search\Model\Table\AppWidgetsTable $table
          */
-        $table = TableRegistry::get('Search.AppWidgets', $config);
+        $table = TableRegistry::getTableLocator()->get('Search.AppWidgets', $config);
         $this->AppWidgets = $table;
 
-        $config = TableRegistry::exists('Search.Widgets') ? [] : ['className' => 'Search\Model\Table\WidgetsTable'];
+        $config = TableRegistry::getTableLocator()->exists('Search.Widgets') ? [] : ['className' => 'Search\Model\Table\WidgetsTable'];
         /**
          * @var \Search\Model\Table\WidgetsTable $table
          */
-        $table = TableRegistry::get('Search.Widgets', $config);
+        $table = TableRegistry::getTableLocator()->get('Search.Widgets', $config);
         $this->Widgets = $table;
     }
 

--- a/tests/TestCase/Widgets/ReportWidgetTest.php
+++ b/tests/TestCase/Widgets/ReportWidgetTest.php
@@ -16,8 +16,8 @@ class ReportWidgetTest extends TestCase
     private const DEFAULT_OPTIONS = ['config' => ['info' => ['renderAs' => 'barChart']]];
 
     public $fixtures = [
-        'plugin.search.widgets',
-        'plugin.search.articles',
+        'plugin.Search.Widgets',
+        'plugin.Search.Articles',
     ];
 
     private $widget;

--- a/tests/TestCase/Widgets/SavedSearchWidgetTest.php
+++ b/tests/TestCase/Widgets/SavedSearchWidgetTest.php
@@ -9,8 +9,8 @@ use Search\Widgets\SavedSearchWidget;
 class SavedSearchWidgetTest extends TestCase
 {
     public $fixtures = [
-        'plugin.Search.saved_searches',
-        'plugin.Search.widgets',
+        'plugin.Search.SavedSearches',
+        'plugin.Search.Widgets',
     ];
 
     private $SavedSearches;


### PR DESCRIPTION
This PR defines v3.8 as the minimum CakePHP version acceptable and fixes most of the deprecation warnings.