### PR TITLE
Changed default value of text fields from empty string to null

### DIFF
--- a/config/Migrations/20190924140921_ExtendSavedSearchColumns.php
+++ b/config/Migrations/20190924140921_ExtendSavedSearchColumns.php
@@ -18,8 +18,8 @@ class ExtendSavedSearchColumns extends AbstractMigration
         $table = $this->table('saved_searches');
 
         $table->addColumn('conjunction', 'string', ['default' => Conjunction::DEFAULT_CONJUNCTION, 'limit' => 10, 'null' => false])
-            ->addColumn('criteria', 'text', ['default' => '', 'limit' => MysqlAdapter::TEXT_LONG, 'null' => false])
-            ->addColumn('fields', 'text', ['default' => '', 'limit' => MysqlAdapter::TEXT_LONG, 'null' => false])
+            ->addColumn('criteria', 'text', ['default' => null, 'limit' => MysqlAdapter::TEXT_LONG, 'null' => false])
+            ->addColumn('fields', 'text', ['default' => null, 'limit' => MysqlAdapter::TEXT_LONG, 'null' => false])
             ->addColumn('group_by', 'string', ['default' => '', 'limit' => 255, 'null' => false])
             ->addColumn('order_by_field', 'string', ['default' => '', 'limit' => 255, 'null' => false])
             ->addColumn('order_by_direction', 'string', ['default' => Direction::DEFAULT_DIRECTION, 'limit' => 10, 'null' => false]);


### PR DESCRIPTION
There are two issues with empty string:
a) It is inconsitent with other tables.
b) It is incompatible with MySQL, which expects a literal default to be given as an expression (see: https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html)